### PR TITLE
feat(auth): OAuth 로그인 URL에 origin 쿼리 파라미터 추가

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -62,7 +62,7 @@ export default function Header({
         "Redirecting to OAuth URL:",
         `${apiBaseUrl}/oauth2/authorization/google`,
       );
-      window.location.href = `${apiBaseUrl}/oauth2/authorization/google`;
+      window.location.href = `${apiBaseUrl}/oauth2/authorization/google?origin=${encodeURIComponent(window.location.origin)}`;
     } else {
       setIsDropdownOpen(!isDropdownOpen);
     }

--- a/app/hooks/usePostDetail.ts
+++ b/app/hooks/usePostDetail.ts
@@ -79,7 +79,7 @@ export function usePostDetail(postId: string) {
     if (!user) {
       const apiBaseUrl =
         process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3000";
-      window.location.href = `${apiBaseUrl}/oauth2/authorization/google`;
+      window.location.href = `${apiBaseUrl}/oauth2/authorization/google?origin=${encodeURIComponent(window.location.origin)}`;
       return;
     }
 
@@ -107,7 +107,7 @@ export function usePostDetail(postId: string) {
       if (message === "UNAUTHORIZED") {
         const apiBaseUrl =
           process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3000";
-        window.location.href = `${apiBaseUrl}/oauth2/authorization/google`;
+        window.location.href = `${apiBaseUrl}/oauth2/authorization/google?origin=${encodeURIComponent(window.location.origin)}`;
         return;
       }
       if (message === "NOT_FOUND") {


### PR DESCRIPTION
## 관련 자료
- 이슈 : #43

## 어떤 작업인가요?
- cross-origin 환경에서 OAuth 인증 후 올바른 프론트엔드로 리다이렉트되지 않는 문제를 해결하기 위해, OAuth 로그인 URL에 `origin` 쿼리 파라미터를 추가합니다.

## 어떻게 해결했나요?
**OAuth URL에 origin 쿼리 파라미터 추가**
- 백엔드에서 `?origin=` 쿼리 파라미터를 우선 읽도록 변경됨에 따라, 프론트엔드의 모든 OAuth 로그인 URL에 `window.location.origin`을 쿼리 파라미터로 추가
- 로컬(localhost:3000), dev, prod 등 환경에 관계없이 올바른 리다이렉트 동작 보장

## 중요한 변경 사항은 무엇인가요?
### OAuth 로그인 URL에 origin 쿼리 파라미터 추가

**Header 로그인 버튼**
- **변경 이유**: 헤더에서 로그인 시 올바른 origin으로 리다이렉트
- **수정 파일**: `app/components/Header.tsx`

**게시물 상세 좋아요 인증**
- **변경 이유**: 미인증 사용자의 좋아요/UNAUTHORIZED 에러 시 올바른 origin으로 리다이렉트
- **수정 파일**: `app/hooks/usePostDetail.ts`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
