### PR TITLE
feat(write): 게시물 수정 모드 추가 및 수정 모드 임시저장/자동저장 비활성화

### DIFF
--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -106,7 +106,7 @@ export default function PostDetailPage() {
       createCommentFieldErrors={createCommentFieldErrors}
       currentUserId={user?.id ?? null}
       onBack={() => router.back()}
-      onEdit={() => alert(t("editNotReady"))}
+      onEdit={() => router.push(`/${locale}/post/write?postId=${post.id}`)}
       onToggleVisibility={handleToggleVisibility}
       onDelete={async () => {
         const deleted = await handleDelete();

--- a/app/post/write/components/WriteActions.tsx
+++ b/app/post/write/components/WriteActions.tsx
@@ -4,6 +4,7 @@ interface WriteActionsProps {
   isSubmitting: boolean;
   isPublishActionDisabled: boolean;
   draftCountLabel: string;
+  showDraftActions?: boolean;
   onGoBack: () => void;
   onSaveDraft: () => void;
   onOpenPublishModal: () => void;
@@ -14,6 +15,7 @@ export default function WriteActions({
   isSubmitting,
   isPublishActionDisabled,
   draftCountLabel,
+  showDraftActions = true,
   onGoBack,
   onSaveDraft,
   onOpenPublishModal,
@@ -32,24 +34,26 @@ export default function WriteActions({
       </button>
 
       <div className="flex gap-3">
-        <div className="inline-flex overflow-hidden rounded-lg bg-muted/80">
-          <button
-            type="button"
-            disabled={isPublishActionDisabled}
-            onClick={onSaveDraft}
-            className="px-4 py-2.5 text-base font-semibold text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isSubmitting ? t("saving") : t("saveDraft")}
-          </button>
-          <button
-            type="button"
-            onClick={onGoDraftList}
-            className="min-w-11 border-l border-border px-2.5 py-2 text-sm font-semibold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            aria-label={t("draftListAria")}
-          >
-            {draftCountLabel}
-          </button>
-        </div>
+        {showDraftActions && (
+          <div className="inline-flex overflow-hidden rounded-lg bg-muted/80">
+            <button
+              type="button"
+              disabled={isPublishActionDisabled}
+              onClick={onSaveDraft}
+              className="px-4 py-2.5 text-base font-semibold text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting ? t("saving") : t("saveDraft")}
+            </button>
+            <button
+              type="button"
+              onClick={onGoDraftList}
+              className="min-w-11 border-l border-border px-2.5 py-2 text-sm font-semibold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              aria-label={t("draftListAria")}
+            >
+              {draftCountLabel}
+            </button>
+          </div>
+        )}
 
         <button
           type="button"

--- a/app/post/write/hooks/useAutoSave.ts
+++ b/app/post/write/hooks/useAutoSave.ts
@@ -13,6 +13,7 @@ import {
 } from "../lib/constants";
 
 interface UseAutoSaveParams {
+  enabled?: boolean;
   user: unknown;
   draftId: string | null;
   draftDetailError: boolean;
@@ -31,6 +32,7 @@ interface UseAutoSaveParams {
 }
 
 export function useAutoSave({
+  enabled = true,
   user,
   draftId,
   draftDetailError,
@@ -63,6 +65,7 @@ export function useAutoSave({
   }, [draftId]);
 
   const runAutoSave = useCallback(async () => {
+    if (!enabled) return;
     if (!user) return;
     if (draftId && draftDetailError) return;
     if (!title.trim() && !content.trim() && !categoryPath.trim() && tags.length === 0) return;
@@ -142,6 +145,7 @@ export function useAutoSave({
     tags.length,
     t,
     title,
+    enabled,
     user,
   ]);
 
@@ -150,6 +154,7 @@ export function useAutoSave({
   }, [runAutoSave]);
 
   useEffect(() => {
+    if (!enabled) return;
     if (!title && !content && !categoryPath && tags.length === 0) return;
 
     if (localSaveDebounceTimerRef.current) {
@@ -185,9 +190,11 @@ export function useAutoSave({
     title,
     writeLocalDraftSnapshot,
     runAutoSave,
+    enabled,
   ]);
 
   useEffect(() => {
+    if (!enabled) return;
     const flushAutoSave = () => {
       if (document.visibilityState === "hidden") {
         writeLocalDraftSnapshot();
@@ -207,7 +214,7 @@ export function useAutoSave({
       document.removeEventListener("visibilitychange", flushAutoSave);
       window.removeEventListener("beforeunload", flushBeforeUnload);
     };
-  });
+  }, [enabled, runAutoSave, writeLocalDraftSnapshot]);
 
   useEffect(() => {
     return () => {

--- a/app/post/write/hooks/useDraftBootstrap.ts
+++ b/app/post/write/hooks/useDraftBootstrap.ts
@@ -2,10 +2,15 @@ import { useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { queryKeys } from "@/app/lib/queryKeys";
-import { fetchDraftPostDetail, fetchDraftPostList } from "@/app/services/posts";
+import {
+  fetchDraftPostDetail,
+  fetchDraftPostList,
+  fetchPostDetailWithMeta,
+} from "@/app/services/posts";
 
 interface UseDraftBootstrapParams {
   draftId: string | null;
+  postId: string | null;
   draftCountQueryKey: readonly unknown[];
   setTitle: (value: string) => void;
   setContent: (value: string) => void;
@@ -15,6 +20,7 @@ interface UseDraftBootstrapParams {
 
 export function useDraftBootstrap({
   draftId,
+  postId,
   draftCountQueryKey,
   setTitle,
   setContent,
@@ -35,8 +41,20 @@ export function useDraftBootstrap({
     refetchOnMount: false,
   });
 
+  const postDetailQuery = useQuery({
+    queryKey: queryKeys.posts.detail(postId ?? ""),
+    queryFn: () => fetchPostDetailWithMeta(postId as string),
+    enabled: !draftId && Boolean(postId),
+    staleTime: Infinity,
+    gcTime: 30 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchOnMount: false,
+  });
+
   const draftCountQuery = useQuery({
     queryKey: draftCountQueryKey,
+    enabled: !postId,
     queryFn: async () => {
       try {
         const firstPage = await fetchDraftPostList({ size: 100 });
@@ -71,29 +89,46 @@ export function useDraftBootstrap({
   });
 
   useEffect(() => {
-    if (!draftDetailQuery.data) return;
-    if (hydratedDraftIdRef.current === draftId) return;
+    const activeId = draftId ?? postId;
+    if (!activeId) return;
+    if (hydratedDraftIdRef.current === activeId) return;
 
-    setTitle(draftDetailQuery.data.post.title || "");
-    setContent(draftDetailQuery.data.post.content || "");
-    setCategoryPath(draftDetailQuery.data.categoryPath || "");
-    setTags(draftDetailQuery.data.post.tags?.map((tag) => tag.name) ?? []);
-    hydratedDraftIdRef.current = draftId;
+    if (draftId && draftDetailQuery.data) {
+      setTitle(draftDetailQuery.data.post.title || "");
+      setContent(draftDetailQuery.data.post.content || "");
+      setCategoryPath(draftDetailQuery.data.categoryPath || "");
+      setTags(draftDetailQuery.data.post.tags?.map((tag) => tag.name) ?? []);
+      hydratedDraftIdRef.current = activeId;
+      return;
+    }
+
+    if (!draftId && postId && postDetailQuery.data) {
+      setTitle(postDetailQuery.data.post.title || "");
+      setContent(postDetailQuery.data.post.content || "");
+      setCategoryPath("");
+      setTags(postDetailQuery.data.post.tags?.map((tag) => tag.name) ?? []);
+      hydratedDraftIdRef.current = activeId;
+    }
   }, [
     draftId,
+    postId,
     draftDetailQuery.data,
+    postDetailQuery.data,
     setCategoryPath,
     setContent,
     setTags,
     setTitle,
   ]);
 
-  const isDraftLoading = Boolean(draftId) && draftDetailQuery.isPending;
+  const isDraftLoading =
+    (Boolean(draftId) && draftDetailQuery.isPending) ||
+    (!draftId && Boolean(postId) && postDetailQuery.isPending);
   const draftErrorMessage = (() => {
-    if (!draftDetailQuery.error) return null;
+    const activeError = draftId ? draftDetailQuery.error : postDetailQuery.error;
+    if (!activeError) return null;
     const message =
-      draftDetailQuery.error instanceof Error
-        ? draftDetailQuery.error.message
+      activeError instanceof Error
+        ? activeError.message
         : "UNKNOWN";
     if (message === "NOT_FOUND") {
       return t("notFound");
@@ -113,9 +148,11 @@ export function useDraftBootstrap({
 
   return {
     draftDetailQuery,
+    postDetailQuery,
     draftCountQuery,
     isDraftLoading,
     draftErrorMessage,
+    detailHasError: Boolean(draftErrorMessage),
     draftCountLabel,
   };
 }

--- a/app/post/write/hooks/usePublishFlow.ts
+++ b/app/post/write/hooks/usePublishFlow.ts
@@ -17,6 +17,7 @@ import { SavePostResult, SavePostVariables } from "../lib/types";
 interface UsePublishFlowParams {
   user: unknown;
   draftId: string | null;
+  postId: string | null;
   draftDetailHasError: boolean;
   queryClient: QueryClient;
   draftCountQueryKey: readonly unknown[];
@@ -39,6 +40,7 @@ interface UsePublishFlowParams {
 export function usePublishFlow({
   user,
   draftId,
+  postId,
   draftDetailHasError,
   queryClient,
   draftCountQueryKey,
@@ -61,6 +63,7 @@ export function usePublishFlow({
   const tPublish = useTranslations("WritePage.publish");
   const tNotice = useTranslations("WritePage.notice");
   const tError = useTranslations("WritePage.errors");
+  const editablePostId = draftId ?? postId;
 
   const removeDraftFromLocalCaches = (targetDraftId: string) => {
     queryClient.setQueriesData<InfiniteData<DraftPostListResult>>(
@@ -102,7 +105,9 @@ export function usePublishFlow({
 
   const savePostMutation = useMutation<SavePostResult, Error, SavePostVariables>({
     mutationFn: async ({ status, payload, source }) => {
-      const result = draftId ? await updatePost(draftId, payload) : await createPost(payload);
+      const result = editablePostId
+        ? await updatePost(editablePostId, payload)
+        : await createPost(payload);
       return {
         result,
         status,
@@ -128,6 +133,11 @@ export function usePublishFlow({
       if (status === "DRAFT") {
         setSuccess(tPublish("draftSaved"));
         clearLocalDraftSnapshot();
+
+        if (postId) {
+          return;
+        }
+
         await Promise.all([
           queryClient.invalidateQueries({
             queryKey: [...queryKeys.posts.all, "drafts"] as const,
@@ -203,7 +213,7 @@ export function usePublishFlow({
 
   const handleSubmit = async (status: PostStatus) => {
     if (!validateRequiredFields()) return;
-    if (draftId && draftDetailHasError) return;
+    if (editablePostId && draftDetailHasError) return;
     const payload = buildPostPayload(status);
     await savePostMutation.mutateAsync({
       status,

--- a/app/post/write/page.tsx
+++ b/app/post/write/page.tsx
@@ -31,6 +31,8 @@ export default function WritePostPage() {
   const searchParams = useSearchParams();
   const { user } = useUser();
   const draftId = searchParams.get("draftId");
+  const postId = searchParams.get("postId");
+  const isPostEditMode = Boolean(postId);
   const localDraftStorageKey = getLocalDraftStorageKey(draftId);
   const draftCountQueryKey = [...queryKeys.posts.all, "drafts-count"] as const;
 
@@ -39,6 +41,7 @@ export default function WritePostPage() {
 
   const draftBootstrap = useDraftBootstrap({
     draftId,
+    postId,
     draftCountQueryKey,
     setTitle: form.setTitle,
     setContent: form.setContent,
@@ -72,9 +75,10 @@ export default function WritePostPage() {
   };
 
   useAutoSave({
+    enabled: !isPostEditMode,
     user,
     draftId,
-    draftDetailError: draftBootstrap.draftDetailQuery.isError,
+    draftDetailError: draftBootstrap.detailHasError,
     title: form.title,
     content: form.content,
     categoryPath: form.categoryPath,
@@ -100,7 +104,8 @@ export default function WritePostPage() {
   const publishFlow = usePublishFlow({
     user,
     draftId,
-    draftDetailHasError: draftBootstrap.draftDetailQuery.isError,
+    postId,
+    draftDetailHasError: draftBootstrap.detailHasError,
     queryClient,
     draftCountQueryKey,
     validateRequiredFields: form.validateRequiredFields,
@@ -137,7 +142,7 @@ export default function WritePostPage() {
       <div className="mx-auto max-w-[1400px]">
         <div className="mb-3 flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
-            {draftId ? t("mode.edit") : t("mode.create")}
+            {draftId || postId ? t("mode.edit") : t("mode.create")}
           </p>
         </div>
 
@@ -208,6 +213,7 @@ export default function WritePostPage() {
               isSubmitting={publishFlow.isSubmitting}
               isPublishActionDisabled={isPublishActionDisabled}
               draftCountLabel={draftBootstrap.draftCountLabel}
+              showDraftActions={!isPostEditMode}
               onGoBack={() => router.push("/?mode=user")}
               onSaveDraft={() => void publishFlow.handleSubmit("DRAFT")}
               onOpenPublishModal={publishFlow.openPublishModal}


### PR DESCRIPTION
## 관련 이슈

- #76 

---

## 변경 내용

- 수정 진입
  - more option button -> 수정 클릭 시 /post/write?postId={postId}로 이동
- write 페이지 모드 분기
  - draftId가 있으면 드래프트 편집 모드
  - postId가 있으면 게시글 수정 모드
- 수정 모드 UI
  - postId 모드에서는 임시저장 + 드래프트 카운트 버튼 숨김
  - 발행 버튼만 남음
- 자동저장
  - postId 모드에서는 useAutoSave가 enabled: false로 동작해 자동저장 비활성화

