### PR TITLE
modify(post-detail): 게시물 상세 첨부파일 URL 매핑을 클라이언트에서 처리

### DIFF
--- a/app/components/PostDetail.tsx
+++ b/app/components/PostDetail.tsx
@@ -18,6 +18,9 @@ import { Comment, FeedMode, Post } from "../types";
 import { CommentSort } from "../services/comments/types";
 import { ValidationErrors } from "../services/comments/apiError";
 
+const ATTACHMENT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 interface PostDetailProps {
   post: Post;
   comments: Comment[];
@@ -120,7 +123,25 @@ export default function PostDetail({
     () => extractTableOfContents(post.content || ""),
     [post.content],
   );
+  const attachmentPresignedUrlMap = useMemo(
+    () =>
+      new Map(
+        (post.attachmentPresignedUrls ?? []).map(({ attachmentId, presignedUrl }) => [
+          attachmentId,
+          presignedUrl,
+        ]),
+      ),
+    [post.attachmentPresignedUrls],
+  );
   const hasTableOfContents = tableOfContents.length > 0;
+
+  const resolvePostImageSrc = (src: string): string | null => {
+    if (!ATTACHMENT_ID_PATTERN.test(src)) {
+      return src;
+    }
+
+    return attachmentPresignedUrlMap.get(src) ?? null;
+  };
 
   const formatCount = (count: number): string => {
     if (locale === "ko") {
@@ -166,7 +187,10 @@ export default function PostDetail({
             />
 
             <article className="mb-12">
-              <MarkdownRenderer content={post.content || ""} />
+              <MarkdownRenderer
+                content={post.content || ""}
+                resolveImageSrc={resolvePostImageSrc}
+              />
             </article>
 
             <PostDetailActionBar

--- a/app/services/posts/mappers.ts
+++ b/app/services/posts/mappers.ts
@@ -97,6 +97,7 @@ export function mapDetailToPost(detail: PostDetailResponse["data"]): Post {
     },
     categoryPath,
     isRead: Boolean(detail.isRead),
+    attachmentPresignedUrls: detail.attachmentPresignedUrls,
     publishedAt: resolvedPublishedAt,
     url: buildCommunityPostPath({
       nickname: detail.author.nickname,

--- a/app/services/posts/types.ts
+++ b/app/services/posts/types.ts
@@ -92,6 +92,10 @@ export interface PostDetailResponse {
     likeStatus?: "NONE" | "LIKE" | "DISLIKE";
     commentCount?: number;
     isRead?: boolean;
+    attachmentPresignedUrls?: {
+      attachmentId: string;
+      presignedUrl: string;
+    }[];
     createdAt: string;
     updatedAt: string;
   };

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -45,6 +45,10 @@ export interface Post {
   techBlog?: TechBlog; // 기업 블로그 글일 경우
   author?: User; // 커뮤니티 글일 경우
   isRead: boolean;
+  attachmentPresignedUrls?: {
+    attachmentId: string;
+    presignedUrl: string;
+  }[];
   publishedAt: string;
   url: string; // 원문 링크 (기업) 또는 내부 링크 (커뮤니티)
 }


### PR DESCRIPTION
## Summary
- 게시물 상세 응답에 `attachmentPresignedUrls` 매핑 정보를 반영했습니다.
- 상세 화면에서 `content` 내부의 attachment UUID를 렌더링 시점에 presigned URL로 치환하도록 변경했습니다.
- 원본 `content`와 수정 플로우는 attachment reference를 그대로 유지합니다.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsc --noEmit`
- `git diff --check -- \"app/components/PostDetail.tsx\" \"app/services/posts/mappers.ts\" \"app/services/posts/types.ts\" \"app/types/index.ts\"`

Co-Authored-By: OpenCode <opencode@openai.com>