### PR TITLE
fix(post-detail): 상세 진입과 뒤로가기 스크롤 애니메이션 제거

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -399,7 +399,3 @@
     background-color: var(--skeleton);
   }
 }
-
-html {
-  scroll-behavior: smooth;
-}


### PR DESCRIPTION
## 어떤 작업인가요?
- 게시물 상세 화면으로 이동하거나 뒤로갈 때 전역 스무스 스크롤 때문에 발생하던 비정상 스크롤 애니메이션을 제거합니다.

## 어떻게 해결했나요?
**전역 스크롤 복원 동작 정리**
- `app/globals.css`에서 전역 `html { scroll-behavior: smooth; }` 설정을 제거했습니다.
- 라우트 전환과 브라우저 스크롤 복원은 기본 동작으로 두고, 목차 이동처럼 필요한 위치 이동만 개별 로직으로 유지했습니다.

## 중요한 변경 사항은 무엇인가요?
### 전역 스크롤 애니메이션 제거

**브라우저 기본 스크롤 복원 유지**
- **변경 이유**: 긴 글 상세 진입 시 화면이 아래에서 위로 움직이거나 뒤로가기 시 스크롤이 어색하게 복원되는 문제를 막기 위해
- **수정 파일**: `app/globals.css`

Co-Authored-By: OpenCode <opencode@openai.com>