### PR TITLE
fix(post-detail): 댓글 작성자 클릭 시 사용자 상세로 이동

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -9,6 +9,7 @@ import { FileText, LogOut, PenLine, Settings } from "lucide-react";
 import { useUser } from "../hooks/useUser";
 import { buildLogoutUrl, redirectToOAuthLogin } from "../lib/authRedirect";
 import { queryKeys } from "../lib/queryKeys";
+import { buildLocalizedUserPath } from "../lib/userRoute";
 import { FEED_MODES } from "../constants/feed";
 import { FeedMode } from "../types";
 import MobileBottomNav from "./BottomNav";
@@ -100,7 +101,7 @@ export default function Header({
       return;
     }
 
-    router.push(`/${locale}/user/${user.id}`);
+    router.push(buildLocalizedUserPath(locale, user.id));
     setIsDropdownOpen(false);
   };
 
@@ -136,7 +137,7 @@ export default function Header({
     }
 
     onModeChange?.(FEED_MODES.USER);
-    router.push(`/${locale}/user/${user.id}`);
+    router.push(buildLocalizedUserPath(locale, user.id));
   };
 
   return (

--- a/app/components/PostCard.tsx
+++ b/app/components/PostCard.tsx
@@ -7,6 +7,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { Post } from "../types";
 import { formatDisplayTime } from "@/app/utils";
 import { buildLocalizedCommunityPostPath } from "@/app/lib/communityPostRoute";
+import { buildLocalizedUserPath } from "@/app/lib/userRoute";
 
 interface PostCardProps {
   post: Post;
@@ -88,7 +89,7 @@ export default function PostCard({
     if (!hasAuthorPage || !post.author?.id) return;
 
     event.stopPropagation();
-    void router.push(`/${locale}/user/${post.author.id}`);
+    void router.push(buildLocalizedUserPath(locale, post.author.id));
   };
 
   const handleCardClick = () => {

--- a/app/components/post-detail/PostDetailCommentItem.tsx
+++ b/app/components/post-detail/PostDetailCommentItem.tsx
@@ -2,9 +2,11 @@
 
 import { ReactNode, useEffect, useRef, useState } from "react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { MoreVertical, Pencil, ThumbsDown, ThumbsUp, Trash2, UserX } from "lucide-react";
 import { Comment } from "@/app/types";
+import { buildLocalizedUserPath } from "@/app/lib/userRoute";
 import { formatDisplayTime } from "@/app/utils";
 import PostDetailConfirmDialog, {
   CANCEL_CONFIRM_BUTTON_CLASS_NAME,
@@ -49,6 +51,7 @@ export default function PostDetailCommentItem({
 }: PostDetailCommentItemProps) {
   const t = useTranslations("PostDetail");
   const locale = useLocale();
+  const router = useRouter();
   const menuRef = useRef<HTMLDivElement | null>(null);
   const editingTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [activeMenu, setActiveMenu] = useState(false);
@@ -66,6 +69,12 @@ export default function PostDetailCommentItem({
     comment.likeStatus === "LIKE" ? "like" : comment.likeStatus === "DISLIKE" ? "dislike" : "none";
   const isReactionDisabled = comment.isDeleted || isBannedComment;
   const shouldShowInteractionRow = !comment.isDeleted && !isBannedComment;
+  const hasAuthorPage = !isBannedComment && Boolean(comment.author.id);
+
+  const handleAuthorClick = () => {
+    if (!hasAuthorPage) return;
+    void router.push(buildLocalizedUserPath(locale, comment.author.id));
+  };
 
   const resizeEditingTextarea = (textarea: HTMLTextAreaElement) => {
     textarea.style.height = "auto";
@@ -139,33 +148,68 @@ export default function PostDetailCommentItem({
 
   return (
     <div className={compact ? "flex gap-2.5" : "flex gap-3"}>
-      <div
-        className={`relative rounded-full overflow-hidden bg-muted flex-shrink-0 flex items-center justify-center ${
-          compact ? "w-7 h-7" : "w-[30px] h-[30px]"
-        }`}
-      >
-        {isBannedComment ? (
-          <UserX className={compact ? "h-3.5 w-3.5 text-muted-foreground" : "h-4 w-4 text-muted-foreground"} />
-        ) : comment.author.profileImageUrl ? (
-          <Image
-            src={comment.author.profileImageUrl}
-            alt={comment.author.name}
-            fill
-            className="object-cover"
-          />
-        ) : (
-          <span className={`${compact ? "text-xs" : "text-sm"} font-bold text-muted-foreground`}>
-            {comment.author.name.charAt(0)}
-          </span>
-        )}
-      </div>
+      {hasAuthorPage ? (
+        <button
+          type="button"
+          onClick={handleAuthorClick}
+          className={`relative rounded-full overflow-hidden bg-muted flex-shrink-0 flex items-center justify-center transition-all duration-150 hover:bg-muted/25 hover:brightness-95 ${
+            compact ? "w-7 h-7" : "w-[30px] h-[30px]"
+          }`}
+          aria-label={`Go to ${comment.author.name || "author"} page`}
+        >
+          {comment.author.profileImageUrl ? (
+            <Image
+              src={comment.author.profileImageUrl}
+              alt={comment.author.name}
+              fill
+              className="object-cover"
+            />
+          ) : (
+            <span className={`${compact ? "text-xs" : "text-sm"} font-bold text-muted-foreground`}>
+              {comment.author.name.charAt(0)}
+            </span>
+          )}
+        </button>
+      ) : (
+        <div
+          className={`relative rounded-full overflow-hidden bg-muted flex-shrink-0 flex items-center justify-center ${
+            compact ? "w-7 h-7" : "w-[30px] h-[30px]"
+          }`}
+        >
+          {isBannedComment ? (
+            <UserX className={compact ? "h-3.5 w-3.5 text-muted-foreground" : "h-4 w-4 text-muted-foreground"} />
+          ) : comment.author.profileImageUrl ? (
+            <Image
+              src={comment.author.profileImageUrl}
+              alt={comment.author.name}
+              fill
+              className="object-cover"
+            />
+          ) : (
+            <span className={`${compact ? "text-xs" : "text-sm"} font-bold text-muted-foreground`}>
+              {comment.author.name.charAt(0)}
+            </span>
+          )}
+        </div>
+      )}
 
       <div className="flex-1 min-w-0">
         <div className={`flex items-center justify-between gap-2 ${compact ? "mb-0.5" : "mb-1"}`}>
           <div className="flex items-center gap-1.5">
-            <span className={`font-semibold ${compact ? "text-xs" : "text-sm"} text-foreground`}>
-              {isBannedComment ? t("commentBannedAuthor") : comment.author.name}
-            </span>
+            {hasAuthorPage ? (
+              <button
+                type="button"
+                onClick={handleAuthorClick}
+                className={`font-semibold text-foreground hover:underline underline-offset-4 ${compact ? "text-xs" : "text-sm"}`}
+                aria-label={`Go to ${comment.author.name || "author"} page`}
+              >
+                {comment.author.name}
+              </button>
+            ) : (
+              <span className={`font-semibold ${compact ? "text-xs" : "text-sm"} text-foreground`}>
+                {isBannedComment ? t("commentBannedAuthor") : comment.author.name}
+              </span>
+            )}
             {isPostAuthor ? <span className="comment-author-badge">{t("commentAuthorBadge")}</span> : null}
             <span className={`${compact ? "text-[11px]" : "text-xs"} text-muted-foreground`}>
               {formatDisplayTime(comment.createdAt, locale)}

--- a/app/lib/userRoute.ts
+++ b/app/lib/userRoute.ts
@@ -1,0 +1,13 @@
+const SEGMENT_SEPARATOR = "/";
+
+function encodePathSegment(value: string): string {
+  return encodeURIComponent(value.trim());
+}
+
+export function buildUserPath(userId: string): string {
+  return ["", "user", encodePathSegment(userId)].join(SEGMENT_SEPARATOR);
+}
+
+export function buildLocalizedUserPath(locale: string, userId: string): string {
+  return `/${encodePathSegment(locale)}${buildUserPath(userId)}`;
+}

--- a/app/post/[postId]/PostDetailPage.tsx
+++ b/app/post/[postId]/PostDetailPage.tsx
@@ -10,6 +10,7 @@ import { useActionSnackbar } from "../../hooks/useActionSnackbar";
 import { useComments } from "../../hooks/useComments";
 import { usePostDetail } from "../../hooks/usePostDetail";
 import { useUser } from "../../hooks/useUser";
+import { buildLocalizedUserPath } from "../../lib/userRoute";
 
 export default function PostDetailPage() {
   const t = useTranslations("PostDetailPage");
@@ -132,6 +133,8 @@ export default function PostDetailPage() {
     );
   }
 
+  const authorId = post.author?.id;
+
   return (
     <>
       <ActionSnackbar
@@ -165,9 +168,9 @@ export default function PostDetailPage() {
         onBack={() => router.back()}
         onEdit={() => router.push(`/${locale}/post/write?postId=${post.id}`)}
         onAuthorClick={
-          post.author?.id
+          authorId
             ? () => {
-                router.push(`/${locale}/user/${post.author?.id}`);
+                router.push(buildLocalizedUserPath(locale, authorId));
               }
             : undefined
         }


### PR DESCRIPTION
## Summary
- 댓글 작성자 아바타와 이름을 누르면 사용자 상세 페이지로 이동하도록 연결했습니다.
- 게시물 목록에서 쓰던 사용자 상세 경로 생성 로직을 `app/lib/userRoute.ts`로 공통화했습니다.
- 상세 작성자 진입 경로도 같은 사용자 상세 경로 생성 함수를 사용하도록 정리했습니다.

## Test
- `npm run lint -- "app/components/PostCard.tsx" "app/components/post-detail/PostDetailCommentItem.tsx" "app/post/[postId]/PostDetailPage.tsx" "app/components/Header.tsx" "app/lib/userRoute.ts"`
- `npx tsc --noEmit`

Co-Authored-By: OpenCode <opencode@openai.com>