### PR TITLE
modify(user): 최하단 카테고리 선택 아이콘을 폴더 상태로 통일

### DIFF
--- a/app/user/[id]/page.tsx
+++ b/app/user/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, type ReactNode, useCallback, useEffect, useMemo, useState } f
 import { useParams, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
-import { ChevronDown, ChevronUp, FileText, Folder, FolderOpen, PencilLine, UserX } from "lucide-react";
+import { ChevronDown, ChevronUp, Folder, FolderOpen, PencilLine, UserX } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { redirectToOAuthLogin } from "../../lib/authRedirect";
 import Header from "../../components/Header";
@@ -158,8 +158,10 @@ function renderCategoryList(params: {
               ) : (
                 <Folder className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
               )
+            ) : isSelected ? (
+              <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
             ) : (
-              <FileText className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <Folder className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
             )}
 
             <span className="whitespace-nowrap">{node.label}</span>


### PR DESCRIPTION
## 관련 자료
- 없음

## 어떤 작업인가요?
- 사용자 상세 페이지 카테고리 목록에서 최하단 항목도 선택 상태를 폴더 아이콘으로 일관되게 보여주기 위한 UI 정리입니다.

## 어떻게 해결했나요?
**leaf 카테고리 아이콘 규칙 정리**
- 상위 카테고리는 기존처럼 펼침 상태에 따라 폴더 아이콘을 유지했습니다.
- 하위가 없는 카테고리는 선택 시 열린 폴더, 미선택 시 닫힌 폴더를 표시하도록 변경했습니다.

**불필요한 아이콘 import 정리**
- 더 이상 사용하지 않는 \`FileText\` import를 제거했습니다.

## 중요한 변경 사항은 무엇인가요?
### leaf 카테고리도 선택 상태를 아이콘에 반영

**선택된 최하단 카테고리 표시 개선**
- **변경 이유**: 선택된 최하단 카테고리만 문서 아이콘으로 보이면 상위 카테고리와 상태 표현이 달라 시각적으로 일관되지 않았습니다.
- **수정 파일**: \`app/user/[id]/page.tsx\`

**사용하지 않는 아이콘 import 제거**
- **변경 이유**: leaf 카테고리 아이콘을 폴더 계열로 통일하면서 \`FileText\` import가 불필요해졌습니다.
- **수정 파일**: \`app/user/[id]/page.tsx\`

Co-Authored-By: OpenCode <opencode@openai.com>