### PR TITLE
게시물 상세 카테고리 탐색 동선 추가

### DIFF
--- a/app/components/PostDetail.tsx
+++ b/app/components/PostDetail.tsx
@@ -35,6 +35,7 @@ interface PostDetailProps {
   currentUserId?: string | null;
   onBack: () => void;
   onEdit: () => void;
+  onCategoryClick?: () => void;
   onToggleVisibility: () => Promise<void> | void;
   onDelete: () => Promise<boolean | void> | boolean | void;
   onReport: () => Promise<void> | void;
@@ -78,6 +79,7 @@ export default function PostDetail({
   currentUserId,
   onBack,
   onEdit,
+  onCategoryClick,
   onToggleVisibility,
   onDelete,
   onReport,
@@ -176,6 +178,7 @@ export default function PostDetail({
               isOwner={isOwner}
               onBack={onBack}
               onEdit={onEdit}
+              onCategoryClick={onCategoryClick}
               onAuthorClick={onAuthorClick}
               onToggleVisibility={() => setIsVisibilityConfirmOpen(true)}
               onRequestDelete={() => setIsDeleteConfirmOpen(true)}

--- a/app/components/post-detail/PostDetailHeader.tsx
+++ b/app/components/post-detail/PostDetailHeader.tsx
@@ -98,12 +98,12 @@ export default function PostDetailHeader({
           <button
             type="button"
             onClick={handleCategoryClick}
-            className="mb-3 inline-flex max-w-full rounded-full bg-muted/85 px-3 py-1 text-sm font-medium text-muted-foreground transition-colors duration-200 hover:bg-muted/40 hover:text-foreground"
+            className="mb-3 inline-flex max-w-full rounded-full bg-muted px-3 py-1 text-sm font-medium text-muted-foreground transition-colors duration-200 hover:bg-muted/90 hover:text-foreground"
           >
             <span className="truncate">{categoryLabel}</span>
           </button>
         ) : (
-          <div className="mb-3 inline-flex max-w-full rounded-full bg-muted/85 px-3 py-1 text-sm font-medium text-muted-foreground">
+          <div className="mb-3 inline-flex max-w-full rounded-full bg-muted px-3 py-1 text-sm font-medium text-muted-foreground">
             <span className="truncate">{categoryLabel}</span>
           </div>
         )

--- a/app/components/post-detail/PostDetailHeader.tsx
+++ b/app/components/post-detail/PostDetailHeader.tsx
@@ -19,6 +19,7 @@ interface PostDetailHeaderProps {
   isOwner: boolean;
   onBack: () => void;
   onEdit: () => void;
+  onCategoryClick?: () => void;
   onToggleVisibility: () => Promise<void> | void;
   onRequestDelete: () => void;
   onRequestReport: () => void;
@@ -34,6 +35,7 @@ export default function PostDetailHeader({
   isOwner,
   onBack,
   onEdit,
+  onCategoryClick,
   onToggleVisibility,
   onRequestDelete,
   onRequestReport,
@@ -65,12 +67,20 @@ export default function PostDetailHeader({
 
   const menuButtonClassName =
     "p-2 rounded-full text-muted-foreground hover:text-foreground transition-colors duration-200";
+  const categoryLabel = post.categoryPath?.trim();
   const hasAuthorClick = Boolean(onAuthorClick && post.author?.id);
+  const hasCategoryClick = Boolean(onCategoryClick && categoryLabel);
 
   const handleAuthorClick = () => {
     if (!hasAuthorClick || !onAuthorClick) return;
 
     onAuthorClick();
+  };
+
+  const handleCategoryClick = () => {
+    if (!hasCategoryClick || !onCategoryClick) return;
+
+    onCategoryClick();
   };
 
   return (
@@ -82,6 +92,22 @@ export default function PostDetailHeader({
         <ArrowLeft className="w-5 h-5" />
         <span className="text-sm font-medium">{t("back")}</span>
       </button>
+
+      {categoryLabel ? (
+        hasCategoryClick ? (
+          <button
+            type="button"
+            onClick={handleCategoryClick}
+            className="mb-3 inline-flex max-w-full rounded-full bg-muted/85 px-3 py-1 text-sm font-medium text-muted-foreground transition-colors duration-200 hover:bg-muted/40 hover:text-foreground"
+          >
+            <span className="truncate">{categoryLabel}</span>
+          </button>
+        ) : (
+          <div className="mb-3 inline-flex max-w-full rounded-full bg-muted/85 px-3 py-1 text-sm font-medium text-muted-foreground">
+            <span className="truncate">{categoryLabel}</span>
+          </div>
+        )
+      ) : null}
 
       <h1 className="text-2xl md:text-4xl font-bold text-foreground leading-tight mb-6">
         {post.title}

--- a/app/post/[postId]/PostDetailPage.tsx
+++ b/app/post/[postId]/PostDetailPage.tsx
@@ -132,6 +132,9 @@ export default function PostDetailPage() {
     );
   }
 
+  const authorId = post.author?.id;
+  const authorCategoryPath = post.categoryPath?.trim();
+
   return (
     <>
       <ActionSnackbar
@@ -164,10 +167,19 @@ export default function PostDetailPage() {
         currentUserId={user?.id ?? null}
         onBack={() => router.back()}
         onEdit={() => router.push(`/${locale}/post/write?postId=${post.id}`)}
-        onAuthorClick={
-          post.author?.id
+        onCategoryClick={
+          authorId && authorCategoryPath
             ? () => {
-                router.push(`/${locale}/user/${post.author?.id}`);
+                router.push(
+                  `/${locale}/user/${authorId}?categoryPath=${encodeURIComponent(authorCategoryPath)}`,
+                );
+              }
+            : undefined
+        }
+        onAuthorClick={
+          authorId
+            ? () => {
+                router.push(`/${locale}/user/${authorId}`);
               }
             : undefined
         }
@@ -183,8 +195,8 @@ export default function PostDetailPage() {
         onReport={async () => {
           setIsRedirectingAfterBlock(true);
           const result = await handleReport();
-          if (result.ok && post.author?.id) {
-            router.replace(`/${locale}/user/${post.author.id}?blocked=1`);
+          if (result.ok && authorId) {
+            router.replace(`/${locale}/user/${authorId}?blocked=1`);
             return;
           }
 

--- a/app/user/[id]/page.tsx
+++ b/app/user/[id]/page.tsx
@@ -111,7 +111,11 @@ function renderCategoryList(params: {
   const renderList = (children: CategoryTreeNode[]): ReactNode[] =>
     children.flatMap((node) => {
       const hasChildren = node.children.length > 0;
-      const shouldAutoExpand = false;
+      const shouldAutoExpand = Boolean(
+        hasChildren
+          && selectedCategoryPath
+          && (selectedCategoryPath === node.path || selectedCategoryPath.startsWith(`${node.path}/`)),
+      );
       const isExpanded = expandedCategoryIds[node.id] ?? shouldAutoExpand;
       const isSelected = selectedCategoryPath === node.path;
 
@@ -252,6 +256,7 @@ function UserDetailPageContent() {
   const searchParams = useSearchParams();
   const userId = typeof params.id === "string" ? params.id : "";
   const isBlockedIntent = searchParams.get("blocked") === "1";
+  const requestedCategoryPath = searchParams.get("categoryPath")?.trim() || null;
   const [currentMode, setCurrentMode] = useState<FeedMode>(FEED_MODES.USER);
 
   const [period, setPeriod] = useState<PostListPeriod>("ALL");
@@ -263,7 +268,7 @@ function UserDetailPageContent() {
   );
   const [isFollowListModalOpen, setIsFollowListModalOpen] = useState(false);
   const [followListTab, setFollowListTab] = useState<FollowListTab>("followers");
-  const [selectedCategoryPath, setSelectedCategoryPath] = useState<string | null>(null);
+  const [selectedCategoryPath, setSelectedCategoryPath] = useState<string | null>(requestedCategoryPath);
   const [expandedCategoryIds, setExpandedCategoryIds] = useState<Record<string, boolean>>({});
   const [isMobileCategorySidebarOpen, setIsMobileCategorySidebarOpen] = useState(false);
 
@@ -347,6 +352,35 @@ function UserDetailPageContent() {
   const handleMobileActionCategorySelect = useCallback((path: string | null) => {
     setSelectedCategoryPath(path);
   }, []);
+
+  useEffect(() => {
+    setSelectedCategoryPath(requestedCategoryPath);
+  }, [requestedCategoryPath]);
+
+  useEffect(() => {
+    if (!requestedCategoryPath) {
+      return;
+    }
+
+    setExpandedCategoryIds((current) => {
+      let changed = false;
+      const next = { ...current };
+
+      for (const category of categoryFilters) {
+        if (
+          requestedCategoryPath === category.path
+          || requestedCategoryPath.startsWith(`${category.path}/`)
+        ) {
+          if (!next[category.id]) {
+            next[category.id] = true;
+            changed = true;
+          }
+        }
+      }
+
+      return changed ? next : current;
+    });
+  }, [categoryFilters, requestedCategoryPath]);
 
   const activeCategoryPath = useMemo(() => {
     if (selectedCategoryPath === null) {


### PR DESCRIPTION
## 어떤 작업인가요?
- 게시물 상세에서 카테고리 맥락을 먼저 보여주고, 같은 카테고리 기준으로 작성자 페이지까지 이어지는 탐색 흐름을 추가합니다.

## 어떻게 해결했나요?
**상세 헤더 카테고리 노출**
- 제목 위에 카테고리 배지를 렌더링합니다.
- 공백 카테고리는 숨기고 클릭 가능한 경우만 이동 동작을 연결합니다.

**작성자 페이지 카테고리 딥링크**
- 카테고리 클릭 시 작성자 페이지에 `categoryPath`를 전달합니다.
- 유저 페이지에서 해당 카테고리를 초기 선택하고 상위 카테고리를 자동 확장합니다.

## 중요한 변경 사항은 무엇인가요?
### 상세 헤더 카테고리 노출

**카테고리 표시와 클릭 동작 추가**
- **변경 이유**: 게시물 제목을 보기 전에 어떤 카테고리 글인지 바로 인지할 수 있어야 합니다.
- **수정 파일**: `app/components/post-detail/PostDetailHeader.tsx`, `app/components/PostDetail.tsx`

### 작성자 페이지 카테고리 딥링크

**카테고리 선택 상태 전달**
- **변경 이유**: 상세에서 고른 카테고리 맥락을 유지한 채 작성자 페이지로 이동할 수 있어야 합니다.
- **수정 파일**: `app/post/[postId]/PostDetailPage.tsx`

**중첩 카테고리 자동 확장**
- **변경 이유**: 하위 카테고리로 바로 진입해도 선택된 위치가 즉시 보여야 합니다.
- **수정 파일**: `app/user/[id]/page.tsx`

<img width="238" height="117" alt="image" src="https://github.com/user-attachments/assets/a22763fb-cafe-4fd9-931e-14a5dcbb403b" />


Co-Authored-By: gpt-5.4 <noreply@openai.com>