### PR TITLE
feat(notifications): 헤더 알림 드롭다운 추가

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -231,80 +231,80 @@ export default function Header({
             </PrimaryRectButton>
           )}
 
-          {isLoggedIn && !isLoading && <NotificationDropdown />}
-
           {/* Auth Button / Profile */}
           {isLoading ? (
             <div className="w-8 h-8 rounded-full skeleton-bg animate-pulse" />
           ) : isLoggedIn && user ? (
-            <div className="relative" ref={dropdownRef}>
-              <button
-                onClick={handleAuthClick}
-                className="flex items-center gap-2 p-1 rounded-full
-                        transition-opacity duration-200
-                        hover:opacity-80"
-              >
-                {user.profileImageUrl ? (
-                  <div className="relative h-8 w-8 shrink-0 overflow-hidden rounded-full bg-muted">
-                    <Image
-                      src={user.profileImageUrl}
-                      alt={user.name || t("profile")}
-                      fill
-                      sizes="32px"
-                      className="object-cover"
-                    />
-                  </div>
-                ) : (
-                  <div className="w-8 h-8 rounded-full bg-muted/80 flex items-center justify-center">
-                    <span className="text-xs font-medium text-muted-foreground">
-                      {user.name?.charAt(0) || "?"}
-                    </span>
+            <div className="flex items-center gap-1.5">
+              <NotificationDropdown />
+
+              <div className="relative" ref={dropdownRef}>
+                <button
+                  onClick={handleAuthClick}
+                  className="flex items-center gap-2 rounded-full p-1 transition-opacity duration-200 hover:opacity-80"
+                >
+                  {user.profileImageUrl ? (
+                    <div className="relative h-8 w-8 shrink-0 overflow-hidden rounded-full bg-muted">
+                      <Image
+                        src={user.profileImageUrl}
+                        alt={user.name || t("profile")}
+                        fill
+                        sizes="32px"
+                        className="object-cover"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted/80">
+                      <span className="text-xs font-medium text-muted-foreground">
+                        {user.name?.charAt(0) || "?"}
+                      </span>
+                    </div>
+                  )}
+                  <span className="hidden md:inline text-sm font-medium text-foreground">
+                    {user.name}
+                  </span>
+                </button>
+
+                {isDropdownOpen && (
+                  <div className="absolute right-0 mt-2 w-52 rounded-md border border-border bg-popover py-1 text-popover-foreground shadow-lg z-[400]">
+                    <div className="border-b border-border px-3 py-2">
+                      <p className="truncate text-sm font-semibold text-foreground">
+                        {user.name}
+                      </p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {user.email}
+                      </p>
+                    </div>
+                    <button
+                      onClick={handleMyPostsMenuClick}
+                      className="w-full whitespace-nowrap px-3 py-2 text-left text-sm font-semibold text-foreground hover:bg-muted transition-colors"
+                    >
+                      <span className="inline-flex items-center gap-2">
+                        <FileText className="h-4 w-4 text-muted-foreground" />
+                        {t("myPosts")}
+                      </span>
+                    </button>
+                    <button
+                      onClick={handleSettingsMenuClick}
+                      className="w-full whitespace-nowrap px-3 py-2 text-left text-sm font-semibold text-foreground hover:bg-muted transition-colors"
+                    >
+                      <span className="inline-flex items-center gap-2">
+                        <Settings className="h-4 w-4 text-muted-foreground" />
+                        {t("settings")}
+                      </span>
+                    </button>
+                    <button
+                      onClick={handleLogout}
+                      className="w-full whitespace-nowrap px-3 py-2 text-left text-sm font-semibold text-foreground hover:bg-muted transition-colors"
+                    >
+                      <span className="inline-flex items-center gap-2">
+                        <LogOut className="h-4 w-4 text-muted-foreground" />
+                        {t("logout")}
+                      </span>
+                    </button>
                   </div>
                 )}
-                <span className="hidden md:inline text-sm font-medium text-foreground">
-                  {user.name}
-                </span>
-              </button>
-
-              {isDropdownOpen && (
-                <div className="absolute right-0 mt-2 w-52 bg-popover text-popover-foreground rounded-md shadow-lg border border-border py-1 z-[400]">
-                  <div className="px-3 py-2 border-b border-border">
-                    <p className="text-sm font-semibold text-foreground truncate">
-                      {user.name}
-                    </p>
-                    <p className="text-xs text-muted-foreground truncate">
-                      {user.email}
-                    </p>
-                  </div>
-                  <button
-                    onClick={handleMyPostsMenuClick}
-                    className="w-full whitespace-nowrap px-3 py-2 text-left text-sm font-semibold text-foreground hover:bg-muted transition-colors"
-                  >
-                    <span className="inline-flex items-center gap-2">
-                      <FileText className="h-4 w-4 text-muted-foreground" />
-                      {t("myPosts")}
-                    </span>
-                  </button>
-                  <button
-                    onClick={handleSettingsMenuClick}
-                    className="w-full whitespace-nowrap px-3 py-2 text-left text-sm font-semibold text-foreground hover:bg-muted transition-colors"
-                  >
-                    <span className="inline-flex items-center gap-2">
-                      <Settings className="h-4 w-4 text-muted-foreground" />
-                      {t("settings")}
-                    </span>
-                  </button>
-                  <button
-                    onClick={handleLogout}
-                    className="w-full whitespace-nowrap px-3 py-2 text-left text-sm font-semibold text-foreground hover:bg-muted transition-colors"
-                  >
-                    <span className="inline-flex items-center gap-2">
-                      <LogOut className="h-4 w-4 text-muted-foreground" />
-                      {t("logout")}
-                    </span>
-                  </button>
-                </div>
-              )}
+              </div>
             </div>
           ) : (
             <button

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -13,6 +13,7 @@ import { buildLocalizedUserPath } from "../lib/userRoute";
 import { FEED_MODES } from "../constants/feed";
 import { FeedMode } from "../types";
 import MobileBottomNav from "./BottomNav";
+import NotificationDropdown from "./header/NotificationDropdown";
 import PrimaryRectButton from "./ui/PrimaryRectButton";
 import SearchInput from "./SearchInput";
 import SettingsModal from "./settings/SettingsModal";
@@ -229,6 +230,8 @@ export default function Header({
               <span>{t("writePost")}</span>
             </PrimaryRectButton>
           )}
+
+          {isLoggedIn && !isLoading && <NotificationDropdown />}
 
           {/* Auth Button / Profile */}
           {isLoading ? (

--- a/app/components/header/NotificationDropdown.tsx
+++ b/app/components/header/NotificationDropdown.tsx
@@ -27,44 +27,59 @@ const notificationSanitizedSchema = {
   },
 } as const;
 
-function NotificationPayloadPreview({ html }: { html: string }) {
-  return (
-    <div className="notification-payload max-h-[72px] overflow-hidden text-[12.5px] leading-[1.5] text-foreground">
-      <ReactMarkdown
-        rehypePlugins={[rehypeRaw, [rehypeSanitize, notificationSanitizedSchema]]}
-        components={{
-          img: ({ src, alt, ...props }) => {
-            if (typeof src !== "string" || src.trim().length === 0) {
-              return null;
-            }
+function stripNotificationImages(html: string): string {
+  return html.replace(/<img\b[^>]*>/gi, "").trim();
+}
 
-            return (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={src}
-                alt={alt ?? ""}
-                {...props}
-              />
-            );
-          },
-        }}
-      >
-        {html}
-      </ReactMarkdown>
+function NotificationPayloadPreview({
+  html,
+  thumbnailUrl,
+}: {
+  html: string;
+  thumbnailUrl?: string | null;
+}) {
+  const normalizedThumbnailUrl =
+    typeof thumbnailUrl === "string" ? thumbnailUrl.trim() : "";
+  const hasThumbnail = normalizedThumbnailUrl.length > 0;
+  const markdownSource = hasThumbnail ? stripNotificationImages(html) : html;
+
+  return (
+    <div className="notification-payload flex max-h-[72px] items-start gap-2 overflow-hidden text-[12.5px] leading-[1.5] text-foreground">
+      {hasThumbnail ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={normalizedThumbnailUrl}
+          alt=""
+          className="notification-payload-thumbnail"
+        />
+      ) : null}
+
+      <div className="notification-payload-body min-w-0 flex-1">
+        <ReactMarkdown
+          rehypePlugins={[rehypeRaw, [rehypeSanitize, notificationSanitizedSchema]]}
+          components={{
+            img: ({ src, alt, ...props }) => {
+              if (typeof src !== "string" || src.trim().length === 0) {
+                return null;
+              }
+
+              return (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={src}
+                  alt={alt ?? ""}
+                  {...props}
+                />
+              );
+            },
+          }}
+        >
+          {markdownSource}
+        </ReactMarkdown>
+      </div>
 
       <style jsx global>{`
-        .notification-payload > div:first-child {
-          display: flex;
-          align-items: flex-start;
-          gap: 8px;
-        }
-
-        .notification-payload > div:first-child > :not(img) {
-          flex: 1 1 auto;
-          min-width: 0;
-        }
-
-        .notification-payload img {
+        .notification-payload-thumbnail {
           width: 42px;
           height: 42px;
           flex-shrink: 0;
@@ -73,20 +88,40 @@ function NotificationPayloadPreview({ html }: { html: string }) {
           background: var(--muted);
         }
 
-        .notification-payload p,
-        .notification-payload div,
-        .notification-payload span {
+        .notification-payload-body > div:first-child {
+          display: flex;
+          align-items: flex-start;
+          gap: 8px;
+        }
+
+        .notification-payload-body > div:first-child > :not(img) {
+          flex: 1 1 auto;
+          min-width: 0;
+        }
+
+        .notification-payload-body img {
+          width: 42px;
+          height: 42px;
+          flex-shrink: 0;
+          border-radius: 9999px;
+          object-fit: cover;
+          background: var(--muted);
+        }
+
+        .notification-payload-body p,
+        .notification-payload-body div,
+        .notification-payload-body span {
           margin: 0;
           min-width: 0;
           overflow-wrap: anywhere;
         }
 
-        .notification-payload a {
+        .notification-payload-body a {
           color: inherit;
           text-decoration: none;
         }
 
-        .notification-payload strong {
+        .notification-payload-body strong {
           font-weight: 600;
         }
       `}</style>
@@ -114,7 +149,10 @@ export default function NotificationDropdown() {
     markNotificationAsRead,
   } = useNotifications({
     enabled: true,
+    listEnabled: isOpen,
   });
+
+  const unreadBadgeLabel = unreadCount > 99 ? "99+" : String(unreadCount);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -174,7 +212,9 @@ export default function NotificationDropdown() {
       >
         <Bell className="h-[17px] w-[17px]" strokeWidth={2.1} />
         {hasUnreadNotifications ? (
-          <span className="absolute right-2 top-2 h-2.5 w-2.5 rounded-full bg-rose-500 ring-2 ring-background" />
+          <span className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground ring-2 ring-background">
+            {unreadBadgeLabel}
+          </span>
         ) : null}
       </button>
 
@@ -185,7 +225,7 @@ export default function NotificationDropdown() {
               <p className="truncate text-[15px] font-semibold tracking-[-0.01em] text-foreground">
                 {t("notifications")}
               </p>
-              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground px-1.5 text-[10px] font-semibold text-background">
+              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[10px] font-semibold text-primary-foreground">
                 {unreadCount}
               </span>
             </div>
@@ -202,7 +242,7 @@ export default function NotificationDropdown() {
             </button>
           </div>
 
-          <div className="max-h-[372px] overflow-y-auto px-4 pb-3 pt-2">
+          <div className="max-h-[372px] overflow-y-auto px-2 pb-3 pt-2">
             {isLoading ? (
               <div className="px-4 py-12 text-center text-sm text-muted-foreground">
                 {t("notificationsLoading")}
@@ -231,19 +271,22 @@ export default function NotificationDropdown() {
                         void handleNotificationClick(notification);
                       }}
                       disabled={!href}
-                      className={`block w-full px-0 py-3 text-left transition-colors hover:bg-muted/45 disabled:cursor-default ${
-                        notification.isRead
-                          ? "bg-transparent"
-                          : "bg-muted/25"
-                      }`}
+                      className="group block w-full rounded-[18px] px-0 py-1 text-left transition-colors focus-visible:outline-none disabled:cursor-default"
                       aria-label={t("notificationsNavigateLabel")}
                     >
-                      <div className="flex items-start gap-3 px-1">
-                        <div className="relative min-w-0 flex-1 pl-4">
+                      <div
+                        className={`flex items-start gap-3 rounded-[16px] px-3 py-2 transition-colors group-hover:bg-muted/50 group-focus-visible:bg-muted/60 ${
+                          notification.isRead ? "bg-transparent" : "bg-muted/25"
+                        }`}
+                      >
+                        <div className="relative min-w-0 flex-1">
                           {!notification.isRead ? (
-                            <span className="absolute left-0 top-1.5 block h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                            <span className="absolute -left-3 top-1.5 block h-2.5 w-2.5 rounded-full bg-emerald-500" />
                           ) : null}
-                          <NotificationPayloadPreview html={notification.payloadHtml} />
+                          <NotificationPayloadPreview
+                            html={notification.payloadHtml}
+                            thumbnailUrl={notification.thumbnailUrl}
+                          />
                           <p className="mt-2 text-[11px] font-medium text-muted-foreground">
                             {formatDisplayTime(notification.createdAt, locale)}
                           </p>

--- a/app/components/header/NotificationDropdown.tsx
+++ b/app/components/header/NotificationDropdown.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { Bell, CheckCheck } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { startTransition, useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import { useNotifications } from "@/app/hooks/useNotifications";
+import { resolveNotificationHref } from "@/app/lib/notificationRoute";
+import { ALLOWED_HTML_TAGS } from "@/app/constants/markdownAllowedHtml";
+import { NotificationListItem } from "@/app/services/notifications";
+import { formatDisplayTime } from "@/app/utils";
+
+const notificationSanitizedSchema = {
+  ...defaultSchema,
+  tagNames: ALLOWED_HTML_TAGS,
+  attributes: {
+    ...defaultSchema.attributes,
+    a: ["href", "title", "target", "rel"],
+    div: ["className", "title", ["align", "left", "center", "right"]],
+    img: ["src", "width", "height", "alt"],
+    span: ["className", "title"],
+    p: [["align", "left", "center", "right"]],
+    strong: ["className"],
+  },
+} as const;
+
+function NotificationPayloadPreview({ html }: { html: string }) {
+  return (
+    <div className="notification-payload max-h-[76px] overflow-hidden text-[13px] leading-[1.45] text-foreground">
+      <ReactMarkdown
+        rehypePlugins={[rehypeRaw, [rehypeSanitize, notificationSanitizedSchema]]}
+        components={{
+          img: ({ src, alt, ...props }) => {
+            if (typeof src !== "string" || src.trim().length === 0) {
+              return null;
+            }
+
+            return (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={src}
+                alt={alt ?? ""}
+                {...props}
+              />
+            );
+          },
+        }}
+      >
+        {html}
+      </ReactMarkdown>
+
+      <style jsx global>{`
+        .notification-payload > div:first-child {
+          display: flex;
+          align-items: flex-start;
+          gap: 12px;
+        }
+
+        .notification-payload img {
+          width: 40px;
+          height: 40px;
+          flex-shrink: 0;
+          border-radius: 9999px;
+          object-fit: cover;
+          background: var(--muted);
+        }
+
+        .notification-payload p,
+        .notification-payload div,
+        .notification-payload span {
+          margin: 0;
+          min-width: 0;
+          overflow-wrap: anywhere;
+        }
+
+        .notification-payload a {
+          color: inherit;
+          text-decoration: none;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+export default function NotificationDropdown() {
+  const t = useTranslations("Header");
+  const locale = useLocale();
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const {
+    notifications,
+    unreadCount,
+    hasUnreadNotifications,
+    errorMessage,
+    hasNext,
+    isLoading,
+    isLoadingMore,
+    isRefreshingReadState,
+    loadMore,
+    markAllAsRead,
+    markNotificationAsRead,
+  } = useNotifications({
+    enabled: true,
+  });
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleNotificationClick = async (notification: NotificationListItem) => {
+    const href = resolveNotificationHref({
+      locale,
+      notification,
+    });
+
+    if (!href) {
+      return;
+    }
+
+    try {
+      await markNotificationAsRead(notification.id);
+    } catch (error) {
+      console.error("Failed to mark notification as read:", error);
+    }
+
+    setIsOpen(false);
+    startTransition(() => {
+      router.push(href);
+    });
+  };
+
+  const handleMarkAllAsRead = async () => {
+    try {
+      await markAllAsRead();
+    } catch (error) {
+      console.error("Failed to mark all notifications as read:", error);
+    }
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((current) => !current)}
+        className="relative inline-flex h-10 w-10 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        aria-label={isOpen ? t("notificationsClose") : t("notificationsOpen")}
+      >
+        <Bell className="h-5 w-5" />
+        {hasUnreadNotifications ? (
+          <span className="absolute right-2.5 top-2.5 h-2.5 w-2.5 rounded-full bg-red-500 ring-2 ring-background" />
+        ) : null}
+      </button>
+
+      {isOpen ? (
+        <div className="absolute right-0 mt-2 w-[360px] max-w-[calc(100vw-1.5rem)] overflow-hidden rounded-2xl border border-border bg-popover text-popover-foreground shadow-[0_20px_60px_rgba(15,23,42,0.18)] z-[420]">
+          <div className="flex items-center justify-between border-b border-border px-4 py-3">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-foreground">
+                {t("notifications")}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {hasUnreadNotifications
+                  ? `${unreadCount}`
+                  : "0"}
+              </p>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => {
+                void handleMarkAllAsRead();
+              }}
+              disabled={!hasUnreadNotifications || isRefreshingReadState}
+              className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs font-semibold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <CheckCheck className="h-3.5 w-3.5" />
+              {t("notificationsMarkAllRead")}
+            </button>
+          </div>
+
+          <div className="max-h-[420px] overflow-y-auto">
+            {isLoading ? (
+              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                {t("notificationsLoading")}
+              </div>
+            ) : errorMessage && notifications.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                {errorMessage}
+              </div>
+            ) : notifications.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                {t("notificationsEmpty")}
+              </div>
+            ) : (
+              <div className="divide-y divide-border">
+                {notifications.map((notification) => {
+                  const href = resolveNotificationHref({
+                    locale,
+                    notification,
+                  });
+
+                  return (
+                    <button
+                      key={notification.id}
+                      type="button"
+                      onClick={() => {
+                        void handleNotificationClick(notification);
+                      }}
+                      disabled={!href}
+                      className={`block w-full px-4 py-3 text-left transition-colors hover:bg-muted/70 disabled:cursor-default ${
+                        notification.isRead
+                          ? "bg-popover"
+                          : "bg-sky-50/70 dark:bg-sky-500/10"
+                      }`}
+                      aria-label={t("notificationsNavigateLabel")}
+                    >
+                      <div className="flex items-start gap-3">
+                        <div className="mt-1 flex-shrink-0">
+                          <span
+                            className={`block h-2.5 w-2.5 rounded-full ${
+                              notification.isRead ? "bg-transparent" : "bg-sky-500"
+                            }`}
+                          />
+                        </div>
+
+                        <div className="min-w-0 flex-1">
+                          <NotificationPayloadPreview html={notification.payloadHtml} />
+                          <p className="mt-2 text-xs text-muted-foreground">
+                            {formatDisplayTime(notification.createdAt, locale)}
+                          </p>
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {hasNext ? (
+            <div className="border-t border-border px-4 py-3">
+              <button
+                type="button"
+                onClick={() => {
+                  void loadMore();
+                }}
+                disabled={isLoadingMore}
+                className="w-full rounded-xl bg-muted px-3 py-2 text-sm font-semibold text-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isLoadingMore ? t("notificationsLoading") : t("notificationsLoadMore")}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/header/NotificationDropdown.tsx
+++ b/app/components/header/NotificationDropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bell, CheckCheck } from "lucide-react";
+import { Bell, ChevronRight } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { startTransition, useEffect, useRef, useState } from "react";
@@ -29,7 +29,7 @@ const notificationSanitizedSchema = {
 
 function NotificationPayloadPreview({ html }: { html: string }) {
   return (
-    <div className="notification-payload max-h-[76px] overflow-hidden text-[13px] leading-[1.45] text-foreground">
+    <div className="notification-payload max-h-[72px] overflow-hidden text-[12.5px] leading-[1.5] text-foreground">
       <ReactMarkdown
         rehypePlugins={[rehypeRaw, [rehypeSanitize, notificationSanitizedSchema]]}
         components={{
@@ -56,12 +56,17 @@ function NotificationPayloadPreview({ html }: { html: string }) {
         .notification-payload > div:first-child {
           display: flex;
           align-items: flex-start;
-          gap: 12px;
+          gap: 8px;
+        }
+
+        .notification-payload > div:first-child > :not(img) {
+          flex: 1 1 auto;
+          min-width: 0;
         }
 
         .notification-payload img {
-          width: 40px;
-          height: 40px;
+          width: 42px;
+          height: 42px;
           flex-shrink: 0;
           border-radius: 9999px;
           object-fit: cover;
@@ -79,6 +84,10 @@ function NotificationPayloadPreview({ html }: { html: string }) {
         .notification-payload a {
           color: inherit;
           text-decoration: none;
+        }
+
+        .notification-payload strong {
+          font-weight: 600;
         }
       `}</style>
     </div>
@@ -156,27 +165,29 @@ export default function NotificationDropdown() {
       <button
         type="button"
         onClick={() => setIsOpen((current) => !current)}
-        className="relative inline-flex h-10 w-10 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        className={`relative inline-flex h-9 w-9 items-center justify-center rounded-full border transition-colors ${
+          isOpen
+            ? "border-border bg-muted/80 text-foreground"
+            : "border-border/70 bg-background text-muted-foreground hover:border-border hover:bg-muted/60 hover:text-foreground"
+        }`}
         aria-label={isOpen ? t("notificationsClose") : t("notificationsOpen")}
       >
-        <Bell className="h-5 w-5" />
+        <Bell className="h-[17px] w-[17px]" strokeWidth={2.1} />
         {hasUnreadNotifications ? (
-          <span className="absolute right-2.5 top-2.5 h-2.5 w-2.5 rounded-full bg-red-500 ring-2 ring-background" />
+          <span className="absolute right-2 top-2 h-2.5 w-2.5 rounded-full bg-rose-500 ring-2 ring-background" />
         ) : null}
       </button>
 
       {isOpen ? (
-        <div className="absolute right-0 mt-2 w-[360px] max-w-[calc(100vw-1.5rem)] overflow-hidden rounded-2xl border border-border bg-popover text-popover-foreground shadow-[0_20px_60px_rgba(15,23,42,0.18)] z-[420]">
-          <div className="flex items-center justify-between border-b border-border px-4 py-3">
-            <div className="min-w-0">
-              <p className="text-sm font-semibold text-foreground">
+        <div className="absolute right-0 top-[calc(100%+0.625rem)] z-[420] w-[338px] max-w-[calc(100vw-1.5rem)] overflow-hidden rounded-[28px] border border-border/80 bg-background text-foreground shadow-[0_24px_70px_rgba(15,23,42,0.16)]">
+          <div className="flex items-center justify-between border-b border-border/70 px-4 pb-3 pt-4">
+            <div className="flex min-w-0 items-center gap-2">
+              <p className="truncate text-[15px] font-semibold tracking-[-0.01em] text-foreground">
                 {t("notifications")}
               </p>
-              <p className="text-xs text-muted-foreground">
-                {hasUnreadNotifications
-                  ? `${unreadCount}`
-                  : "0"}
-              </p>
+              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground px-1.5 text-[10px] font-semibold text-background">
+                {unreadCount}
+              </span>
             </div>
 
             <button
@@ -185,28 +196,27 @@ export default function NotificationDropdown() {
                 void handleMarkAllAsRead();
               }}
               disabled={!hasUnreadNotifications || isRefreshingReadState}
-              className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs font-semibold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-full px-2 py-1 text-[11px] font-semibold text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
             >
-              <CheckCheck className="h-3.5 w-3.5" />
               {t("notificationsMarkAllRead")}
             </button>
           </div>
 
-          <div className="max-h-[420px] overflow-y-auto">
+          <div className="max-h-[372px] overflow-y-auto px-4 pb-3 pt-2">
             {isLoading ? (
-              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              <div className="px-4 py-12 text-center text-sm text-muted-foreground">
                 {t("notificationsLoading")}
               </div>
             ) : errorMessage && notifications.length === 0 ? (
-              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              <div className="px-4 py-12 text-center text-sm text-muted-foreground">
                 {errorMessage}
               </div>
             ) : notifications.length === 0 ? (
-              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              <div className="px-4 py-12 text-center text-sm text-muted-foreground">
                 {t("notificationsEmpty")}
               </div>
             ) : (
-              <div className="divide-y divide-border">
+              <div className="divide-y divide-border/60">
                 {notifications.map((notification) => {
                   const href = resolveNotificationHref({
                     locale,
@@ -221,25 +231,20 @@ export default function NotificationDropdown() {
                         void handleNotificationClick(notification);
                       }}
                       disabled={!href}
-                      className={`block w-full px-4 py-3 text-left transition-colors hover:bg-muted/70 disabled:cursor-default ${
+                      className={`block w-full px-0 py-3 text-left transition-colors hover:bg-muted/45 disabled:cursor-default ${
                         notification.isRead
-                          ? "bg-popover"
-                          : "bg-sky-50/70 dark:bg-sky-500/10"
+                          ? "bg-transparent"
+                          : "bg-muted/25"
                       }`}
                       aria-label={t("notificationsNavigateLabel")}
                     >
-                      <div className="flex items-start gap-3">
-                        <div className="mt-1 flex-shrink-0">
-                          <span
-                            className={`block h-2.5 w-2.5 rounded-full ${
-                              notification.isRead ? "bg-transparent" : "bg-sky-500"
-                            }`}
-                          />
-                        </div>
-
-                        <div className="min-w-0 flex-1">
+                      <div className="flex items-start gap-3 px-1">
+                        <div className="relative min-w-0 flex-1 pl-4">
+                          {!notification.isRead ? (
+                            <span className="absolute left-0 top-1.5 block h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                          ) : null}
                           <NotificationPayloadPreview html={notification.payloadHtml} />
-                          <p className="mt-2 text-xs text-muted-foreground">
+                          <p className="mt-2 text-[11px] font-medium text-muted-foreground">
                             {formatDisplayTime(notification.createdAt, locale)}
                           </p>
                         </div>
@@ -252,16 +257,17 @@ export default function NotificationDropdown() {
           </div>
 
           {hasNext ? (
-            <div className="border-t border-border px-4 py-3">
+            <div className="border-t border-border/70 px-4 py-3">
               <button
                 type="button"
                 onClick={() => {
                   void loadMore();
                 }}
                 disabled={isLoadingMore}
-                className="w-full rounded-xl bg-muted px-3 py-2 text-sm font-semibold text-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-60"
+                className="mx-auto inline-flex min-w-[118px] items-center justify-center gap-1 rounded-full border border-border/80 bg-background px-4 py-2 text-sm font-semibold text-foreground shadow-sm transition-colors hover:bg-muted/60 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {isLoadingMore ? t("notificationsLoading") : t("notificationsLoadMore")}
+                <ChevronRight className="h-4 w-4" />
               </button>
             </div>
           ) : null}

--- a/app/hooks/useNotifications.ts
+++ b/app/hooks/useNotifications.ts
@@ -1,0 +1,186 @@
+"use client";
+
+import {
+  InfiniteData,
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
+import { useTranslations } from "next-intl";
+import {
+  fetchNotifications,
+  FetchNotificationsResponse,
+  markNotificationsRead,
+  NotificationListItem,
+} from "../services/notifications";
+import { queryKeys } from "../lib/queryKeys";
+
+interface UseNotificationsOptions {
+  enabled: boolean;
+  size?: number;
+}
+
+function mergeNotifications(pages: FetchNotificationsResponse[]): NotificationListItem[] {
+  const deduped = new Map<string, NotificationListItem>();
+
+  pages
+    .flatMap((page) => page.data.content)
+    .forEach((notification) => {
+      if (!deduped.has(notification.id)) {
+        deduped.set(notification.id, notification);
+      }
+    });
+
+  return Array.from(deduped.values());
+}
+
+function updateInfiniteNotifications(
+  current:
+    | InfiniteData<FetchNotificationsResponse, string | undefined>
+    | undefined,
+  updatedNotifications: NotificationListItem[],
+): InfiniteData<FetchNotificationsResponse, string | undefined> | undefined {
+  if (!current) {
+    return current;
+  }
+
+  const updatedById = new Map(
+    updatedNotifications.map((notification) => [notification.id, notification]),
+  );
+
+  return {
+    ...current,
+    pages: current.pages.map((page) => ({
+      ...page,
+      data: {
+        ...page.data,
+        content: page.data.content.map((notification) => {
+          const updated = updatedById.get(notification.id);
+          return updated
+            ? {
+                ...notification,
+                ...updated,
+              }
+            : notification;
+        }),
+      },
+    })),
+  };
+}
+
+export function useNotifications({
+  enabled,
+  size = 20,
+}: UseNotificationsOptions) {
+  const t = useTranslations("Header");
+  const queryClient = useQueryClient();
+  const queryKey = queryKeys.notifications.list({ size });
+
+  const query = useInfiniteQuery({
+    queryKey,
+    enabled,
+    initialPageParam: undefined as string | undefined,
+    queryFn: async ({ pageParam }) =>
+      fetchNotifications({
+        cursor: pageParam,
+        size,
+      }),
+    getNextPageParam: (lastPage) => lastPage.data.nextCursor ?? undefined,
+  });
+
+  const readMutation = useMutation({
+    mutationFn: async (notificationIds: string[]) => {
+      if (notificationIds.length === 0) {
+        return [] as NotificationListItem[];
+      }
+
+      const result = await markNotificationsRead(notificationIds);
+      return result.data.notifications;
+    },
+    onSuccess: (updatedNotifications) => {
+      if (updatedNotifications.length === 0) {
+        return;
+      }
+
+      queryClient.setQueryData<
+        InfiniteData<FetchNotificationsResponse, string | undefined> | undefined
+      >(queryKey, (current) =>
+        updateInfiniteNotifications(current, updatedNotifications),
+      );
+    },
+  });
+
+  const notifications = useMemo(
+    () => mergeNotifications(query.data?.pages ?? []),
+    [query.data?.pages],
+  );
+
+  const unreadNotifications = useMemo(
+    () => notifications.filter((notification) => !notification.isRead),
+    [notifications],
+  );
+
+  const unreadNotificationIds = useMemo(
+    () => unreadNotifications.map((notification) => notification.id),
+    [unreadNotifications],
+  );
+
+  const loadMore = useCallback(async () => {
+    if (!query.hasNextPage || query.isFetchingNextPage) {
+      return;
+    }
+
+    await query.fetchNextPage();
+  }, [query]);
+
+  const markAllAsRead = useCallback(async () => {
+    if (unreadNotificationIds.length === 0) {
+      return [];
+    }
+
+    return readMutation.mutateAsync(unreadNotificationIds);
+  }, [readMutation, unreadNotificationIds]);
+
+  const markNotificationAsRead = useCallback(
+    async (notificationId: string) => {
+      const target = notifications.find(
+        (notification) => notification.id === notificationId,
+      );
+
+      if (!target || target.isRead) {
+        return [];
+      }
+
+      return readMutation.mutateAsync([notificationId]);
+    },
+    [notifications, readMutation],
+  );
+
+  const errorMessage = (() => {
+    if (!query.error) return null;
+
+    const message =
+      query.error instanceof Error ? query.error.message : "UNKNOWN_ERROR";
+
+    if (message === "UNAUTHORIZED") {
+      return t("notificationsLoginRequired");
+    }
+
+    return t("notificationsLoadFailed");
+  })();
+
+  return {
+    notifications,
+    unreadCount: unreadNotifications.length,
+    hasUnreadNotifications: unreadNotifications.length > 0,
+    errorMessage,
+    hasNext: Boolean(query.hasNextPage),
+    isLoading: query.isPending,
+    isLoadingMore: query.isFetchingNextPage,
+    isRefreshingReadState: readMutation.isPending,
+    loadMore,
+    markAllAsRead,
+    markNotificationAsRead,
+  };
+}

--- a/app/hooks/useNotifications.ts
+++ b/app/hooks/useNotifications.ts
@@ -4,6 +4,7 @@ import {
   InfiniteData,
   useInfiniteQuery,
   useMutation,
+  useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
@@ -11,6 +12,7 @@ import { useTranslations } from "next-intl";
 import {
   fetchNotifications,
   FetchNotificationsResponse,
+  fetchUnreadNotificationCount,
   markNotificationsRead,
   NotificationListItem,
 } from "../services/notifications";
@@ -18,6 +20,7 @@ import { queryKeys } from "../lib/queryKeys";
 
 interface UseNotificationsOptions {
   enabled: boolean;
+  listEnabled?: boolean;
   size?: number;
 }
 
@@ -71,15 +74,23 @@ function updateInfiniteNotifications(
 
 export function useNotifications({
   enabled,
+  listEnabled = true,
   size = 20,
 }: UseNotificationsOptions) {
   const t = useTranslations("Header");
   const queryClient = useQueryClient();
   const queryKey = queryKeys.notifications.list({ size });
+  const unreadCountQueryKey = queryKeys.notifications.unreadCount();
+
+  const unreadCountQuery = useQuery({
+    queryKey: unreadCountQueryKey,
+    enabled,
+    queryFn: fetchUnreadNotificationCount,
+  });
 
   const query = useInfiniteQuery({
     queryKey,
-    enabled,
+    enabled: enabled && listEnabled,
     initialPageParam: undefined as string | undefined,
     queryFn: async ({ pageParam }) =>
       fetchNotifications({
@@ -108,6 +119,14 @@ export function useNotifications({
       >(queryKey, (current) =>
         updateInfiniteNotifications(current, updatedNotifications),
       );
+
+      queryClient.setQueryData<number | undefined>(
+        unreadCountQueryKey,
+        (current) =>
+          typeof current === "number"
+            ? Math.max(0, current - updatedNotifications.length)
+            : current,
+      );
     },
   });
 
@@ -125,6 +144,9 @@ export function useNotifications({
     () => unreadNotifications.map((notification) => notification.id),
     [unreadNotifications],
   );
+
+  const unreadCount =
+    unreadCountQuery.data ?? unreadNotifications.length;
 
   const loadMore = useCallback(async () => {
     if (!query.hasNextPage || query.isFetchingNextPage) {
@@ -172,8 +194,8 @@ export function useNotifications({
 
   return {
     notifications,
-    unreadCount: unreadNotifications.length,
-    hasUnreadNotifications: unreadNotifications.length > 0,
+    unreadCount,
+    hasUnreadNotifications: unreadCount > 0,
     errorMessage,
     hasNext: Boolean(query.hasNextPage),
     isLoading: query.isPending,

--- a/app/lib/notificationRoute.ts
+++ b/app/lib/notificationRoute.ts
@@ -1,0 +1,61 @@
+import { buildLocalizedUserPath } from "./userRoute";
+import {
+  NotificationArgument,
+  NotificationListItem,
+  NotificationTargetType,
+  NotificationType,
+} from "../services/notifications";
+
+function encodePathSegment(value: string): string {
+  return encodeURIComponent(value.trim());
+}
+
+function findTargetId(
+  argumentsList: NotificationArgument[],
+  targetType: NotificationTargetType,
+): string | null {
+  const target = argumentsList.find((argument) => argument.targetType === targetType);
+  return target?.targetId ?? null;
+}
+
+function buildLocalizedPostPath(locale: string, postId: string): string {
+  return `/${encodePathSegment(locale)}/post/${encodePathSegment(postId)}`;
+}
+
+function shouldRouteToPost(type: NotificationType): boolean {
+  return type === "POST_COMMENT" || type === "COMMENT_REPLY" || type === "FOLLOWER_POST";
+}
+
+export function resolveNotificationHref(params: {
+  locale: string;
+  notification: Pick<NotificationListItem, "type" | "arguments">;
+}): string | null {
+  const { locale, notification } = params;
+
+  if (notification.type === "FOLLOW") {
+    const userId = findTargetId(notification.arguments, "USER");
+    return userId ? buildLocalizedUserPath(locale, userId) : null;
+  }
+
+  if (shouldRouteToPost(notification.type)) {
+    const postId = findTargetId(notification.arguments, "POST");
+    if (!postId) {
+      return null;
+    }
+
+    const commentId = findTargetId(notification.arguments, "COMMENT");
+    const basePath = buildLocalizedPostPath(locale, postId);
+
+    if (!commentId) {
+      return basePath;
+    }
+
+    const searchParams = new URLSearchParams({
+      commentId,
+    });
+
+    return `${basePath}?${searchParams.toString()}`;
+  }
+
+  return null;
+}

--- a/app/lib/queryKeys.ts
+++ b/app/lib/queryKeys.ts
@@ -59,4 +59,9 @@ export const queryKeys = {
     list: (signature?: string) =>
       [...queryKeys.techBlogs.all, "list", signature ?? "default"] as const,
   },
+  notifications: {
+    all: ["notifications"] as const,
+    list: (params: { size: number }) =>
+      [...queryKeys.notifications.all, "list", params] as const,
+  },
 };

--- a/app/lib/queryKeys.ts
+++ b/app/lib/queryKeys.ts
@@ -63,5 +63,6 @@ export const queryKeys = {
     all: ["notifications"] as const,
     list: (params: { size: number }) =>
       [...queryKeys.notifications.all, "list", params] as const,
+    unreadCount: () => [...queryKeys.notifications.all, "unread-count"] as const,
   },
 };

--- a/app/services/notifications/client.ts
+++ b/app/services/notifications/client.ts
@@ -1,0 +1,81 @@
+import { httpClient } from "@/app/utils/httpClient";
+import {
+  FetchNotificationsRequest,
+  FetchNotificationsResponse,
+  MarkNotificationsReadRequest,
+  MarkNotificationsReadResponse,
+} from "./types";
+
+function extractMessage(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null) return undefined;
+  const message = (body as { message?: unknown }).message;
+  return typeof message === "string" ? message : undefined;
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  return response.json();
+}
+
+function buildNotificationsPath(params?: FetchNotificationsRequest): string {
+  const searchParams = new URLSearchParams();
+
+  if (params?.cursor) {
+    searchParams.set("cursor", params.cursor);
+  }
+
+  if (typeof params?.size === "number") {
+    searchParams.set("size", String(params.size));
+  }
+
+  const query = searchParams.toString();
+  return query ? `/api/notifications?${query}` : "/api/notifications";
+}
+
+export async function fetchNotificationsRequest(
+  params?: FetchNotificationsRequest,
+): Promise<FetchNotificationsResponse> {
+  const response = await httpClient(buildNotificationsPath(params), {
+    method: "GET",
+  });
+
+  if (response.status === 401) {
+    throw new Error("UNAUTHORIZED");
+  }
+
+  if (response.status === 400) {
+    const body = await parseJson(response).catch(() => null);
+    throw new Error(extractMessage(body) || "BAD_REQUEST");
+  }
+
+  if (!response.ok) {
+    throw new Error(`HTTP_${response.status}`);
+  }
+
+  const result = await parseJson(response);
+  return result as FetchNotificationsResponse;
+}
+
+export async function markNotificationsReadRequest(
+  payload: MarkNotificationsReadRequest,
+): Promise<MarkNotificationsReadResponse> {
+  const response = await httpClient("/api/notifications/read", {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+
+  if (response.status === 401) {
+    throw new Error("UNAUTHORIZED");
+  }
+
+  if (response.status === 400) {
+    const body = await parseJson(response).catch(() => null);
+    throw new Error(extractMessage(body) || "BAD_REQUEST");
+  }
+
+  if (!response.ok) {
+    throw new Error(`HTTP_${response.status}`);
+  }
+
+  const result = await parseJson(response);
+  return result as MarkNotificationsReadResponse;
+}

--- a/app/services/notifications/client.ts
+++ b/app/services/notifications/client.ts
@@ -2,6 +2,7 @@ import { httpClient } from "@/app/utils/httpClient";
 import {
   FetchNotificationsRequest,
   FetchNotificationsResponse,
+  FetchUnreadNotificationCountResponse,
   MarkNotificationsReadRequest,
   MarkNotificationsReadResponse,
 } from "./types";
@@ -53,6 +54,28 @@ export async function fetchNotificationsRequest(
 
   const result = await parseJson(response);
   return result as FetchNotificationsResponse;
+}
+
+export async function fetchUnreadNotificationCountRequest(): Promise<FetchUnreadNotificationCountResponse> {
+  const response = await httpClient("/api/notifications/unread-count", {
+    method: "GET",
+  });
+
+  if (response.status === 401) {
+    throw new Error("UNAUTHORIZED");
+  }
+
+  if (response.status === 400) {
+    const body = await parseJson(response).catch(() => null);
+    throw new Error(extractMessage(body) || "BAD_REQUEST");
+  }
+
+  if (!response.ok) {
+    throw new Error(`HTTP_${response.status}`);
+  }
+
+  const result = await parseJson(response);
+  return result as FetchUnreadNotificationCountResponse;
 }
 
 export async function markNotificationsReadRequest(

--- a/app/services/notifications/index.ts
+++ b/app/services/notifications/index.ts
@@ -1,0 +1,23 @@
+import {
+  fetchNotificationsRequest,
+  markNotificationsReadRequest,
+} from "./client";
+import {
+  FetchNotificationsRequest,
+  FetchNotificationsResponse,
+  MarkNotificationsReadResponse,
+} from "./types";
+
+export async function fetchNotifications(
+  params?: FetchNotificationsRequest,
+): Promise<FetchNotificationsResponse> {
+  return fetchNotificationsRequest(params);
+}
+
+export async function markNotificationsRead(
+  notificationIds: string[],
+): Promise<MarkNotificationsReadResponse> {
+  return markNotificationsReadRequest({ notificationIds });
+}
+
+export * from "./types";

--- a/app/services/notifications/index.ts
+++ b/app/services/notifications/index.ts
@@ -1,17 +1,44 @@
 import {
   fetchNotificationsRequest,
+  fetchUnreadNotificationCountRequest,
   markNotificationsReadRequest,
 } from "./client";
 import {
   FetchNotificationsRequest,
   FetchNotificationsResponse,
+  FetchUnreadNotificationCountResponse,
   MarkNotificationsReadResponse,
 } from "./types";
+
+function normalizeUnreadNotificationCount(
+  response: FetchUnreadNotificationCountResponse,
+): number {
+  const { data } = response;
+
+  if (typeof data === "number") {
+    return data;
+  }
+
+  if (typeof data?.unreadCount === "number") {
+    return data.unreadCount;
+  }
+
+  if (typeof data?.count === "number") {
+    return data.count;
+  }
+
+  return 0;
+}
 
 export async function fetchNotifications(
   params?: FetchNotificationsRequest,
 ): Promise<FetchNotificationsResponse> {
   return fetchNotificationsRequest(params);
+}
+
+export async function fetchUnreadNotificationCount(): Promise<number> {
+  const response = await fetchUnreadNotificationCountRequest();
+  return normalizeUnreadNotificationCount(response);
 }
 
 export async function markNotificationsRead(

--- a/app/services/notifications/types.ts
+++ b/app/services/notifications/types.ts
@@ -15,6 +15,7 @@ export interface NotificationListItem {
   id: string;
   type: NotificationType;
   payloadHtml: string;
+  thumbnailUrl?: string | null;
   isRead: boolean;
   readAt: string | null;
   createdAt: string;
@@ -48,5 +49,16 @@ export interface MarkNotificationsReadResponse {
   data: {
     notifications: NotificationListItem[];
   };
+  message: string;
+}
+
+export interface FetchUnreadNotificationCountResponse {
+  status: number | Record<string, unknown>;
+  data:
+    | number
+    | {
+        unreadCount?: number;
+        count?: number;
+      };
   message: string;
 }

--- a/app/services/notifications/types.ts
+++ b/app/services/notifications/types.ts
@@ -1,0 +1,52 @@
+export type NotificationType =
+  | "POST_COMMENT"
+  | "COMMENT_REPLY"
+  | "FOLLOWER_POST"
+  | "FOLLOW";
+
+export type NotificationTargetType = "USER" | "POST" | "COMMENT";
+
+export interface NotificationArgument {
+  targetType: NotificationTargetType;
+  targetId: string;
+}
+
+export interface NotificationListItem {
+  id: string;
+  type: NotificationType;
+  payloadHtml: string;
+  isRead: boolean;
+  readAt: string | null;
+  createdAt: string;
+  arguments: NotificationArgument[];
+}
+
+export interface CursorPageResponse<T> {
+  content: T[];
+  nextCursor: string | null;
+  hasNext: boolean;
+  size: number;
+}
+
+export interface FetchNotificationsResponse {
+  status: number | Record<string, unknown>;
+  data: CursorPageResponse<NotificationListItem>;
+  message: string;
+}
+
+export interface FetchNotificationsRequest {
+  cursor?: string;
+  size?: number;
+}
+
+export interface MarkNotificationsReadRequest {
+  notificationIds: string[];
+}
+
+export interface MarkNotificationsReadResponse {
+  status: number | Record<string, unknown>;
+  data: {
+    notifications: NotificationListItem[];
+  };
+  message: string;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,7 +9,17 @@
     "logout": "Log out",
     "login": "Log in",
     "myPosts": "My posts",
-    "settings": "Settings"
+    "settings": "Settings",
+    "notifications": "Notifications",
+    "notificationsOpen": "Open notifications",
+    "notificationsClose": "Close notifications",
+    "notificationsLoadFailed": "Failed to load notifications.",
+    "notificationsLoginRequired": "Sign in to view notifications.",
+    "notificationsEmpty": "No notifications yet.",
+    "notificationsMarkAllRead": "Mark all read",
+    "notificationsLoading": "Loading notifications...",
+    "notificationsLoadMore": "Load more",
+    "notificationsNavigateLabel": "Go to notification"
   },
   "BottomNav": {
     "home": "Home",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -9,7 +9,17 @@
     "logout": "ログアウト",
     "login": "ログイン",
     "myPosts": "自分の記事",
-    "settings": "設定"
+    "settings": "設定",
+    "notifications": "通知",
+    "notificationsOpen": "通知を開く",
+    "notificationsClose": "通知を閉じる",
+    "notificationsLoadFailed": "通知の読み込みに失敗しました。",
+    "notificationsLoginRequired": "通知を確認するにはログインが必要です。",
+    "notificationsEmpty": "新しい通知はありません。",
+    "notificationsMarkAllRead": "すべて既読",
+    "notificationsLoading": "通知を読み込み中です。",
+    "notificationsLoadMore": "もっと見る",
+    "notificationsNavigateLabel": "通知へ移動"
   },
   "BottomNav": {
     "home": "ホーム",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -9,7 +9,17 @@
     "logout": "로그아웃",
     "login": "로그인",
     "myPosts": "내 글",
-    "settings": "설정"
+    "settings": "설정",
+    "notifications": "알림",
+    "notificationsOpen": "알림 열기",
+    "notificationsClose": "알림 닫기",
+    "notificationsLoadFailed": "알림을 불러오지 못했습니다.",
+    "notificationsLoginRequired": "로그인 후 알림을 확인할 수 있습니다.",
+    "notificationsEmpty": "새 알림이 없습니다.",
+    "notificationsMarkAllRead": "모두 읽음",
+    "notificationsLoading": "알림을 불러오는 중입니다.",
+    "notificationsLoadMore": "더보기",
+    "notificationsNavigateLabel": "알림으로 이동"
   },
   "BottomNav": {
     "home": "홈",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -9,7 +9,17 @@
     "logout": "退出登录",
     "login": "登录",
     "myPosts": "我的文章",
-    "settings": "设置"
+    "settings": "设置",
+    "notifications": "通知",
+    "notificationsOpen": "打开通知",
+    "notificationsClose": "关闭通知",
+    "notificationsLoadFailed": "无法加载通知。",
+    "notificationsLoginRequired": "登录后可查看通知。",
+    "notificationsEmpty": "暂无新通知。",
+    "notificationsMarkAllRead": "全部已读",
+    "notificationsLoading": "正在加载通知...",
+    "notificationsLoadMore": "加载更多",
+    "notificationsNavigateLabel": "前往通知"
   },
   "BottomNav": {
     "home": "首页",


### PR DESCRIPTION
## 관련 자료
- 이슈 : 없음

## 어떤 작업인가요?
- 헤더에서 알림 목록을 바로 확인하고 읽음 처리까지 할 수 있도록 알림 드롭다운 UI와 API 연동을 추가하고, 후속 피드백에 맞춰 배치와 시각 스타일을 다듬었습니다.

## 어떻게 해결했나요?
**알림 데이터 계층 추가**
- 알림 목록 조회와 다건 읽음 처리를 위한 서비스 타입, 클라이언트, React Query 훅을 추가했습니다.
- 알림 목록 병합, 미읽음 계산, 읽음 처리 후 캐시 반영을 훅에서 담당하도록 분리했습니다.

**헤더 드롭다운과 이동 흐름 연결**
- 헤더 우측 사용자 영역에 bell 버튼과 드롭다운 패널을 추가했습니다.
- `payloadHtml`을 제한된 영역에서 sanitize해 렌더링하고, 알림 클릭 시 읽음 처리 후 사용자/게시물 화면으로 이동하도록 연결했습니다.

**후속 UI 피드백 반영**
- 알림 버튼을 프로필 바로 옆으로 옮기고 드롭다운을 더 컴팩트한 레이아웃으로 조정했습니다.
- 알림 목록의 카드 느낌을 줄이고, 읽지 않은 개수 표시와 payload 내 이미지 간격을 다듬었습니다.

## 중요한 변경 사항은 무엇인가요?
### 알림 API와 상태 관리 추가

**알림 조회/읽음 처리 전용 계층을 분리**
- **변경 이유**: 헤더 UI가 fetch 로직과 캐시 갱신을 직접 가지지 않게 해서 목록 조회, 읽음 처리, 더보기 로직을 재사용 가능하게 만들기 위해서입니다.
- **수정 파일**: `app/services/notifications/client.ts`, `app/services/notifications/index.ts`, `app/services/notifications/types.ts`, `app/hooks/useNotifications.ts`, `app/lib/queryKeys.ts`

**알림 타입별 이동 경로를 별도 헬퍼로 정리**
- **변경 이유**: `FOLLOW`, 댓글, 게시물 알림마다 이동 규칙이 달라서 UI 컴포넌트 밖에서 경로 계산 책임을 분리하기 위해서입니다.
- **수정 파일**: `app/lib/notificationRoute.ts`

### 헤더 알림 드롭다운 UI 추가

**백엔드 HTML payload를 제한된 영역에 렌더링하고 읽음 동작을 연결**
- **변경 이유**: 서버가 내려주는 알림 UI를 그대로 활용하되, 고정된 드롭다운 영역 안에서 이미지와 텍스트 overflow를 제어하고 클릭 시 읽음 처리와 이동을 함께 보장해야 했기 때문입니다.
- **수정 파일**: `app/components/header/NotificationDropdown.tsx`

**알림 버튼 위치와 리스트 스타일을 후속 피드백에 맞게 조정**
- **변경 이유**: 프로필 옆 배치, 더 단정한 목록 밀도, 읽지 않은 개수 표시, payload 이미지 간격 등 실제 사용 피드백을 반영해 헤더 사용성을 높이기 위해서입니다.
- **수정 파일**: `app/components/Header.tsx`, `app/components/header/NotificationDropdown.tsx`, `messages/ko.json`, `messages/en.json`, `messages/ja.json`, `messages/zh.json`

Co-Authored-By: OpenAI Codex <codex@openai.com>
