### PR TITLE
fix(markdown): 게시물 본문 링크 스타일 구분

### DIFF
--- a/app/components/MarkdownRenderer.styles.test.mjs
+++ b/app/components/MarkdownRenderer.styles.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const markdownRendererSource = readFileSync(
+  new URL("./MarkdownRenderer.tsx", import.meta.url),
+  "utf8",
+);
+
+function escapeRegExp(pattern) {
+  return pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getCssRuleBody(selector) {
+  const ruleMatch = markdownRendererSource.match(
+    new RegExp(`${escapeRegExp(selector)}\\s*\\{(?<body>[\\s\\S]*?)\\n\\s*\\}`, "m"),
+  );
+
+  assert.ok(ruleMatch?.groups?.body, `${selector} CSS rule should exist`);
+
+  return ruleMatch.groups.body;
+}
+
+test("markdown links have a visible link affordance", () => {
+  const linkRuleBody = getCssRuleBody(".markdown-content a");
+
+  assert.match(linkRuleBody, /color:\s*var\(--color-blue-500\);/);
+  assert.match(linkRuleBody, /text-decoration-line:\s*underline;/);
+  assert.match(linkRuleBody, /text-underline-offset:\s*0\.18em;/);
+  assert.match(linkRuleBody, /overflow-wrap:\s*anywhere;/);
+  assert.doesNotMatch(linkRuleBody, /text-decoration:\s*none;/);
+});
+
+test("markdown links show hover and keyboard focus states", () => {
+  const interactiveRuleMatch = markdownRendererSource.match(
+    /\.markdown-content a:hover,\s*\.markdown-content a:focus-visible\s*\{(?<body>[\s\S]*?)\n\s*\}/m,
+  );
+
+  assert.ok(
+    interactiveRuleMatch?.groups?.body,
+    "hover and focus-visible CSS rule should exist",
+  );
+  assert.match(interactiveRuleMatch.groups.body, /color:\s*var\(--comment-submit-button-hover\);/);
+  assert.match(interactiveRuleMatch.groups.body, /background-color:/);
+
+  assert.match(
+    markdownRendererSource,
+    /\.markdown-content a:focus-visible\s*\{\s*outline:\s*2px solid var\(--color-blue-500\);\s*outline-offset:\s*2px;/m,
+  );
+});

--- a/app/components/MarkdownRenderer.tsx
+++ b/app/components/MarkdownRenderer.tsx
@@ -326,14 +326,31 @@ export default function MarkdownRenderer({
 
         /* 링크 */
         .markdown-content a {
-          color: var(--primary);
-          text-decoration: none;
-          transition: opacity 0.2s ease;
+          color: var(--color-blue-500);
+          font-weight: 500;
+          text-decoration-line: underline;
+          text-decoration-thickness: 0.08em;
+          text-underline-offset: 0.18em;
+          overflow-wrap: anywhere;
+          border-radius: 3px;
+          transition:
+            color 0.2s ease,
+            background-color 0.2s ease;
         }
 
-        .markdown-content a:hover {
-          opacity: 0.8;
-          text-decoration: underline;
+        .markdown-content a:hover,
+        .markdown-content a:focus-visible {
+          color: var(--comment-submit-button-hover);
+          background-color: color-mix(
+            in srgb,
+            var(--color-blue-500) 12%,
+            transparent
+          );
+        }
+
+        .markdown-content a:focus-visible {
+          outline: 2px solid var(--color-blue-500);
+          outline-offset: 2px;
         }
 
         /* 테이블 (GFM) */


### PR DESCRIPTION
## 어떤 작업인가요?
- 게시물 상세 본문에서 raw URL과 마크다운 링크가 일반 텍스트와 구분되도록 링크 스타일을 개선합니다.

## 어떻게 해결했나요?
**마크다운 링크 스타일 개선**
- `MarkdownRenderer`의 anchor 스타일을 파란색, 밑줄, hover/focus 상태로 변경했습니다.
- 긴 URL이 본문 레이아웃을 깨지 않도록 `overflow-wrap: anywhere`를 적용했습니다.

**링크 스타일 회귀 테스트 추가**
- 링크 색상, 밑줄, hover/focus-visible 상태를 검증하는 Node test를 추가했습니다.

## 중요한 변경 사항은 무엇인가요?
### 게시물 본문 링크 구분 강화

**링크 기본 상태 시각화**
- **변경 이유**: 기존 링크가 본문 색상과 밑줄 제거 상태로 렌더링되어 클릭 가능한 텍스트인지 구분하기 어려웠습니다.
- **수정 파일**: `app/components/MarkdownRenderer.tsx`

**회귀 방지 테스트 추가**
- **변경 이유**: 링크 스타일이 다시 일반 텍스트처럼 보이지 않도록 핵심 CSS 속성을 검증합니다.
- **수정 파일**: `app/components/MarkdownRenderer.styles.test.mjs`
