### PR TITLE
feat(settings): 프로필 수정 진입 경로 추가

### DIFF
--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import AppModal from "../common/AppModal";
 import SettingsPanel from "./SettingsPanel";
 
@@ -10,25 +9,13 @@ interface SettingsModalProps {
 }
 
 export default function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
-  const [isProfileEditModalOpen, setIsProfileEditModalOpen] = useState(false);
-
-  const handleClose = () => {
-    setIsProfileEditModalOpen(false);
-    onClose();
-  };
-
   return (
     <AppModal
       isOpen={isOpen}
-      onClose={handleClose}
-      closeOnBackdrop={!isProfileEditModalOpen}
-      closeOnEscape={!isProfileEditModalOpen}
+      onClose={onClose}
       panelClassName="w-full max-w-[660px]"
     >
-      <SettingsPanel
-        onClose={handleClose}
-        onProfileEditOpenChange={setIsProfileEditModalOpen}
-      />
+      <SettingsPanel onClose={onClose} />
     </AppModal>
   );
 }

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import AppModal from "../common/AppModal";
 import SettingsPanel from "./SettingsPanel";
 
@@ -9,13 +10,25 @@ interface SettingsModalProps {
 }
 
 export default function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+  const [isProfileEditModalOpen, setIsProfileEditModalOpen] = useState(false);
+
+  const handleClose = () => {
+    setIsProfileEditModalOpen(false);
+    onClose();
+  };
+
   return (
     <AppModal
       isOpen={isOpen}
-      onClose={onClose}
+      onClose={handleClose}
+      closeOnBackdrop={!isProfileEditModalOpen}
+      closeOnEscape={!isProfileEditModalOpen}
       panelClassName="w-full max-w-[660px]"
     >
-      <SettingsPanel onClose={onClose} />
+      <SettingsPanel
+        onClose={handleClose}
+        onProfileEditOpenChange={setIsProfileEditModalOpen}
+      />
     </AppModal>
   );
 }

--- a/src/components/settings/SettingsPanel.profile-edit.test.mjs
+++ b/src/components/settings/SettingsPanel.profile-edit.test.mjs
@@ -7,25 +7,42 @@ const settingsPanelSource = readFileSync(
   "utf8",
 );
 
-test("settings management profile row opens the profile edit modal", () => {
+const settingsModalSource = readFileSync(
+  new URL("./SettingsModal.tsx", import.meta.url),
+  "utf8",
+);
+
+test("settings management profile row opens the profile edit modal through a body portal", () => {
   assert.match(
     settingsPanelSource,
     /import ProfileEditModal from "\.\.\/user\/ProfileEditModal";/,
   );
   assert.match(
     settingsPanelSource,
-    /const \[isProfileEditModalOpen, setIsProfileEditModalOpen\] = useState\(false\);/,
+    /import \{ createPortal \} from "react-dom";/,
   );
   assert.match(
     settingsPanelSource,
-    /onClick=\{\(\) => setIsProfileEditModalOpen\(true\)\}/,
+    /document\.body/,
   );
   assert.match(
     settingsPanelSource,
-    /aria-label=\{`\$\{t\("management\.profile"\)\} \$\{t\("management\.edit"\)\}`\}/,
+    /user && isProfileEditModalOpen && [a-zA-Z]+ &&\s*createPortal\(/,
   );
+  assert.doesNotMatch(settingsPanelSource, /\{user \? \(\s*<ProfileEditModal/);
+});
+
+test("settings modal keeps parent dismissal disabled while profile editor is open", () => {
   assert.match(
     settingsPanelSource,
-    /<ProfileEditModal\s+isOpen=\{isProfileEditModalOpen\}\s+user=\{user\}\s+onClose=\{\(\) => setIsProfileEditModalOpen\(false\)\}/m,
+    /onProfileEditOpenChange\?\.\(isProfileEditModalOpen\);/,
+  );
+  assert.match(
+    settingsModalSource,
+    /closeOnBackdrop=\{!isProfileEditModalOpen\}/,
+  );
+  assert.match(
+    settingsModalSource,
+    /closeOnEscape=\{!isProfileEditModalOpen\}/,
   );
 });

--- a/src/components/settings/SettingsPanel.profile-edit.test.mjs
+++ b/src/components/settings/SettingsPanel.profile-edit.test.mjs
@@ -7,42 +7,25 @@ const settingsPanelSource = readFileSync(
   "utf8",
 );
 
-const settingsModalSource = readFileSync(
-  new URL("./SettingsModal.tsx", import.meta.url),
-  "utf8",
-);
-
-test("settings management profile row opens the profile edit modal through a body portal", () => {
+test("settings management profile row opens the profile edit modal", () => {
   assert.match(
     settingsPanelSource,
     /import ProfileEditModal from "\.\.\/user\/ProfileEditModal";/,
   );
   assert.match(
     settingsPanelSource,
-    /import \{ createPortal \} from "react-dom";/,
+    /const \[isProfileEditModalOpen, setIsProfileEditModalOpen\] = useState\(false\);/,
   );
   assert.match(
     settingsPanelSource,
-    /document\.body/,
+    /onClick=\{\(\) => setIsProfileEditModalOpen\(true\)\}/,
   );
   assert.match(
     settingsPanelSource,
-    /user && isProfileEditModalOpen && [a-zA-Z]+ &&\s*createPortal\(/,
+    /aria-label=\{`\$\{t\("management\.profile"\)\} \$\{t\("management\.edit"\)\}`\}/,
   );
-  assert.doesNotMatch(settingsPanelSource, /\{user \? \(\s*<ProfileEditModal/);
-});
-
-test("settings modal keeps parent dismissal disabled while profile editor is open", () => {
   assert.match(
     settingsPanelSource,
-    /onProfileEditOpenChange\?\.\(isProfileEditModalOpen\);/,
-  );
-  assert.match(
-    settingsModalSource,
-    /closeOnBackdrop=\{!isProfileEditModalOpen\}/,
-  );
-  assert.match(
-    settingsModalSource,
-    /closeOnEscape=\{!isProfileEditModalOpen\}/,
+    /<ProfileEditModal\s+isOpen=\{isProfileEditModalOpen\}\s+user=\{user\}\s+onClose=\{\(\) => setIsProfileEditModalOpen\(false\)\}/m,
   );
 });

--- a/src/components/settings/SettingsPanel.profile-edit.test.mjs
+++ b/src/components/settings/SettingsPanel.profile-edit.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const settingsPanelSource = readFileSync(
+  new URL("./SettingsPanel.tsx", import.meta.url),
+  "utf8",
+);
+
+test("settings management profile row opens the profile edit modal", () => {
+  assert.match(
+    settingsPanelSource,
+    /import ProfileEditModal from "\.\.\/user\/ProfileEditModal";/,
+  );
+  assert.match(
+    settingsPanelSource,
+    /const \[isProfileEditModalOpen, setIsProfileEditModalOpen\] = useState\(false\);/,
+  );
+  assert.match(
+    settingsPanelSource,
+    /onClick=\{\(\) => setIsProfileEditModalOpen\(true\)\}/,
+  );
+  assert.match(
+    settingsPanelSource,
+    /aria-label=\{`\$\{t\("management\.profile"\)\} \$\{t\("management\.edit"\)\}`\}/,
+  );
+  assert.match(
+    settingsPanelSource,
+    /<ProfileEditModal\s+isOpen=\{isProfileEditModalOpen\}\s+user=\{user\}\s+onClose=\{\(\) => setIsProfileEditModalOpen\(false\)\}/m,
+  );
+});

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -14,6 +14,7 @@ import { redirectToOAuthLogin } from "../../lib/authRedirect";
 import { useUserBans } from "../../hooks/useUserBans";
 import BlockedAccountsModal from "./BlockedAccountsModal";
 import ActionSnackbar from "../ui/ActionSnackbar";
+import ProfileEditModal from "../user/ProfileEditModal";
 
 type ThemeMode = "light" | "dark" | "system";
 type SettingsTab = "general" | "management";
@@ -83,6 +84,7 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
   const { theme, setTheme } = useTheme();
   const [activeTab, setActiveTab] = useState<SettingsTab>("general");
   const [isBlockedAccountsModalOpen, setIsBlockedAccountsModalOpen] = useState(false);
+  const [isProfileEditModalOpen, setIsProfileEditModalOpen] = useState(false);
   const { snackbar, showSnackbar } = useActionSnackbar();
   const {
     bans,
@@ -251,7 +253,12 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
             <article className="p-0">
               <section>
                 <h3 className="text-base font-semibold text-foreground">{t("management.profile")}</h3>
-                <div className="mt-3 flex items-center px-1 py-2">
+                <button
+                  type="button"
+                  onClick={() => setIsProfileEditModalOpen(true)}
+                  aria-label={`${t("management.profile")} ${t("management.edit")}`}
+                  className="mt-3 flex w-full items-center justify-between rounded-md px-1 py-2 text-left transition-colors hover:bg-muted/60"
+                >
                   <div className="flex min-w-0 items-center gap-3">
                     <div className="relative h-8 w-8 overflow-hidden rounded-full bg-muted">
                       {user.profileImageUrl ? (
@@ -269,7 +276,11 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
                     </div>
                     <p className="truncate text-sm font-semibold text-foreground">{user.name}</p>
                   </div>
-                </div>
+                  <span className="ml-3 inline-flex shrink-0 items-center gap-1 text-sm font-semibold text-muted-foreground">
+                    {t("management.edit")}
+                    <ChevronRight className="h-5 w-5" />
+                  </span>
+                </button>
               </section>
 
               <section className="mt-6 border-t border-border pt-6">
@@ -298,6 +309,13 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
           onClose={() => setIsBlockedAccountsModalOpen(false)}
           onUnban={handleUnbanUser}
         />
+        {user ? (
+          <ProfileEditModal
+            isOpen={isProfileEditModalOpen}
+            user={user}
+            onClose={() => setIsProfileEditModalOpen(false)}
+          />
+        ) : null}
       </div>
     </>
   );

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { useLocale, useTranslations } from "next-intl";
 import Image from "next/image";
 import { ChevronRight, X } from "lucide-react";
@@ -21,6 +22,7 @@ type SettingsTab = "general" | "management";
 
 interface SettingsPanelProps {
   onClose?: () => void;
+  onProfileEditOpenChange?: (isOpen: boolean) => void;
 }
 
 function ThemePreview({ mode, isActive }: { mode: ThemeMode; isActive: boolean }) {
@@ -73,7 +75,10 @@ function ThemePreview({ mode, isActive }: { mode: ThemeMode; isActive: boolean }
   );
 }
 
-export default function SettingsPanel({ onClose }: SettingsPanelProps) {
+export default function SettingsPanel({
+  onClose,
+  onProfileEditOpenChange,
+}: SettingsPanelProps) {
   const t = useTranslations("SettingsPage");
   const tTheme = useTranslations("Theme");
   const locale = useLocale();
@@ -115,6 +120,16 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
   );
 
   const activeTabTitle = activeTab === "general" ? t("tabs.general") : t("tabs.management");
+  const profileEditPortalElement =
+    typeof document === "undefined" ? null : document.body;
+
+  useEffect(() => {
+    onProfileEditOpenChange?.(isProfileEditModalOpen);
+
+    return () => {
+      onProfileEditOpenChange?.(false);
+    };
+  }, [isProfileEditModalOpen, onProfileEditOpenChange]);
 
   const handleUnbanUser = async (targetUserId: string) => {
     const result = await unbanByUserId(targetUserId);
@@ -309,14 +324,16 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
           onClose={() => setIsBlockedAccountsModalOpen(false)}
           onUnban={handleUnbanUser}
         />
-        {user ? (
+      </div>
+      {user && isProfileEditModalOpen && profileEditPortalElement &&
+        createPortal(
           <ProfileEditModal
             isOpen={isProfileEditModalOpen}
             user={user}
             onClose={() => setIsProfileEditModalOpen(false)}
-          />
-        ) : null}
-      </div>
+          />,
+          profileEditPortalElement,
+        )}
     </>
   );
 }

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -309,13 +309,13 @@ export default function SettingsPanel({ onClose }: SettingsPanelProps) {
           onClose={() => setIsBlockedAccountsModalOpen(false)}
           onUnban={handleUnbanUser}
         />
-        {user ? (
+        {user && (
           <ProfileEditModal
             isOpen={isProfileEditModalOpen}
             user={user}
             onClose={() => setIsProfileEditModalOpen(false)}
           />
-        ) : null}
+        )}
       </div>
     </>
   );

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import Image from "next/image";
 import { ChevronRight, X } from "lucide-react";
@@ -22,7 +21,6 @@ type SettingsTab = "general" | "management";
 
 interface SettingsPanelProps {
   onClose?: () => void;
-  onProfileEditOpenChange?: (isOpen: boolean) => void;
 }
 
 function ThemePreview({ mode, isActive }: { mode: ThemeMode; isActive: boolean }) {
@@ -75,10 +73,7 @@ function ThemePreview({ mode, isActive }: { mode: ThemeMode; isActive: boolean }
   );
 }
 
-export default function SettingsPanel({
-  onClose,
-  onProfileEditOpenChange,
-}: SettingsPanelProps) {
+export default function SettingsPanel({ onClose }: SettingsPanelProps) {
   const t = useTranslations("SettingsPage");
   const tTheme = useTranslations("Theme");
   const locale = useLocale();
@@ -120,16 +115,6 @@ export default function SettingsPanel({
   );
 
   const activeTabTitle = activeTab === "general" ? t("tabs.general") : t("tabs.management");
-  const profileEditPortalElement =
-    typeof document === "undefined" ? null : document.body;
-
-  useEffect(() => {
-    onProfileEditOpenChange?.(isProfileEditModalOpen);
-
-    return () => {
-      onProfileEditOpenChange?.(false);
-    };
-  }, [isProfileEditModalOpen, onProfileEditOpenChange]);
 
   const handleUnbanUser = async (targetUserId: string) => {
     const result = await unbanByUserId(targetUserId);
@@ -324,16 +309,14 @@ export default function SettingsPanel({
           onClose={() => setIsBlockedAccountsModalOpen(false)}
           onUnban={handleUnbanUser}
         />
-      </div>
-      {user && isProfileEditModalOpen && profileEditPortalElement &&
-        createPortal(
+        {user ? (
           <ProfileEditModal
             isOpen={isProfileEditModalOpen}
             user={user}
             onClose={() => setIsProfileEditModalOpen(false)}
-          />,
-          profileEditPortalElement,
-        )}
+          />
+        ) : null}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## 관련 자료
- 이슈: https://github.com/Techtaurant/fe/issues/143

## 어떤 작업인가요?
- 설정 관리 탭의 프로필 영역에서도 기존 프로필 수정 화면으로 진입할 수 있도록 연결합니다.

## 어떻게 해결했나요?
**설정 프로필 수정 진입 연결**
- 프로필 요약 영역을 접근 가능한 버튼으로 변경했습니다.
- 클릭 시 기존 `ProfileEditModal`을 열도록 상태를 추가했습니다.

**회귀 테스트 추가**
- 설정 패널이 프로필 수정 모달을 import하고 여는 구조를 정적 테스트로 고정했습니다.

## 중요한 변경 사항은 무엇인가요?
### 설정 관리 탭 프로필 영역

**프로필 요약 영역 버튼화**
- **변경 이유**: 설정 화면에서도 닉네임과 프로필 이미지 수정 동선을 제공하기 위해서입니다.
- **수정 파일**: `src/components/settings/SettingsPanel.tsx`

**프로필 수정 진입 회귀 테스트**
- **변경 이유**: 설정 프로필 영역에서 수정 모달을 여는 계약이 깨지지 않도록 하기 위해서입니다.
- **수정 파일**: `src/components/settings/SettingsPanel.profile-edit.test.mjs`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.

Co-authored-by: OpenAI Codex <codex@openai.com>

