### PR TITLE
[codex] Allow localhost image host

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,12 @@ const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       {
+        protocol: "http",
+        hostname: "localhost",
+        port: "8080",
+        pathname: "/static/images/**",
+      },
+      {
         protocol: "https",
         hostname: "**",
       },


### PR DESCRIPTION
## Summary
- Allow `http://localhost:8080/static/images/**` in Next.js image remote patterns.
- Fix local backend thumbnail URLs being rejected by `next/image`.

## Root Cause
`next/image` only accepts remote image sources whose protocol, host, port, and path match `images.remotePatterns`. The existing config allowed HTTPS hosts but not the local HTTP backend image host.

## Validation
- `pnpm exec eslint next.config.ts`