### PR TITLE
modify(home): 커뮤니티 홈 기본 피드 정리

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,64 +1,34 @@
 "use client";
 
-import { Link } from "../i18n/navigation";
+import { Link, usePathname } from "../i18n/navigation";
 import { useTranslations } from "next-intl";
-import { FEED_MODES } from "../constants/feed";
-import { FeedMode } from "../types";
 
 interface MobileBottomNavProps {
-  currentMode?: FeedMode;
   onMyPostsClick: () => void;
-  onModeNavigate: (mode: FeedMode) => void;
   onWritePost: () => void;
 }
 
 export default function MobileBottomNav({
-  currentMode = FEED_MODES.COMPANY,
   onMyPostsClick,
-  onModeNavigate,
   onWritePost,
 }: MobileBottomNavProps) {
   const t = useTranslations("BottomNav");
+  const pathname = usePathname();
+  const isHome = pathname === "/";
 
   return (
     <nav className="md:hidden fixed bottom-0 left-0 right-0 z-[350] pb-[env(safe-area-inset-bottom)]">
       <div className="w-full">
         <div className="bg-background/95 backdrop-blur border-t border-border shadow-lg px-3 py-2">
           <div className="mx-auto max-w-[520px] flex items-center justify-between">
-            <button
-              type="button"
-              onClick={() => onModeNavigate(FEED_MODES.COMPANY)}
+            <Link
+              href="/"
               className={`flex flex-col items-center gap-1 px-2 py-1 text-[11px] transition-colors ${
-                currentMode === FEED_MODES.COMPANY
+                isHome
                   ? "text-foreground"
                   : "text-muted-foreground hover:text-foreground"
               }`}
-              aria-label={t("companyBlogs")}
-            >
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 7a2 2 0 012-2h8a2 2 0 012 2v12H6a2 2 0 01-2-2V7zM16 9h2a2 2 0 012 2v8a2 2 0 01-2 2h-2V9z"
-                />
-              </svg>
-              <span>{t("companyBlogs")}</span>
-            </button>
-
-            <button
-              type="button"
-              onClick={() => onModeNavigate(FEED_MODES.USER)}
-              className={`flex flex-col items-center gap-1 px-2 py-1 text-[11px] transition-colors ${
-                currentMode === FEED_MODES.USER
-                  ? "text-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
+              aria-current={isHome ? "page" : undefined}
               aria-label={t("community")}
             >
               <svg
@@ -75,7 +45,7 @@ export default function MobileBottomNav({
                 />
               </svg>
               <span>{t("community")}</span>
-            </button>
+            </Link>
 
             <button
               type="button"

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -27,10 +27,10 @@ export default function FilterBar({ filterState, onFilterChange }: FilterBarProp
   ];
 
   const sortOptions: { label: string; value: SortOption }[] = [
-    { label: t('sort.latest'), value: 'latest' },
-    { label: t('sort.comments'), value: 'comments' },
     { label: t('sort.views'), value: 'views' },
     { label: t('sort.likes'), value: 'likes' },
+    { label: t('sort.latest'), value: 'latest' },
+    { label: t('sort.comments'), value: 'comments' },
   ];
 
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,8 +11,6 @@ import { useUser } from "../hooks/useUser";
 import { buildLogoutUrl, redirectToOAuthLogin } from "../lib/authRedirect";
 import { queryKeys } from "../lib/queryKeys";
 import { buildUserPath } from "../lib/userRoute";
-import { FEED_MODES } from "../constants/feed";
-import { FeedMode } from "../types";
 import MobileBottomNav from "./BottomNav";
 import NotificationDropdown from "./header/NotificationDropdown";
 import PrimaryRectButton from "./ui/PrimaryRectButton";
@@ -21,14 +19,10 @@ import SettingsModal from "./settings/SettingsModal";
 
 interface HeaderProps {
   onMenuClick?: () => void;
-  currentMode?: FeedMode;
-  onModeChange?: (mode: FeedMode) => void;
 }
 
 export default function Header({
   onMenuClick,
-  currentMode = FEED_MODES.COMPANY,
-  onModeChange,
 }: HeaderProps) {
   const t = useTranslations("Header");
   const pathname = usePathname();
@@ -75,14 +69,6 @@ export default function Header({
     router.push({
       pathname: "/search",
       query: { q: trimmedQuery },
-    });
-  };
-
-  const handleModeNavigate = (mode: FeedMode) => {
-    onModeChange?.(mode);
-    router.push({
-      pathname: "/",
-      query: { mode },
     });
   };
 
@@ -143,7 +129,6 @@ export default function Header({
       return;
     }
 
-    onModeChange?.(FEED_MODES.USER);
     router.push(buildUserPath(user.id));
   };
 
@@ -185,31 +170,6 @@ export default function Header({
             Techtaurant
           </h1>
 
-          {/* Mode Switcher (Desktop) */}
-          <div className="hidden md:flex items-center gap-1">
-            <button
-              onClick={() => handleModeNavigate(FEED_MODES.COMPANY)}
-              className={`px-3 py-2 rounded-md text-sm font-medium transition-colors
-                ${
-                  currentMode === FEED_MODES.COMPANY
-                    ? "text-foreground bg-muted"
-                    : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                }`}
-            >
-              {t("companyBlogs")}
-            </button>
-            <button
-              onClick={() => handleModeNavigate(FEED_MODES.USER)}
-              className={`px-3 py-2 rounded-md text-sm font-medium transition-colors
-                ${
-                  currentMode === FEED_MODES.USER
-                    ? "text-foreground bg-muted"
-                    : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                }`}
-            >
-              {t("community")}
-            </button>
-          </div>
         </div>
 
         {/* Search Bar (데스크탑만) */}
@@ -340,9 +300,7 @@ export default function Header({
       </div>
 
       <MobileBottomNav
-        currentMode={currentMode}
         onMyPostsClick={handleMyPostsClick}
-        onModeNavigate={handleModeNavigate}
         onWritePost={handleWritePostClick}
       />
 

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -71,7 +71,7 @@ function sanitizePostPreview(rawContent: string): string {
 }
 
 function buildTagRoute(tagId: string): string {
-  return `/?mode=user&tagIds=${encodeURIComponent(tagId)}`;
+  return `/?tagIds=${encodeURIComponent(tagId)}`;
 }
 
 export default function PostCard({

--- a/src/components/PostDetail.tsx
+++ b/src/components/PostDetail.tsx
@@ -16,7 +16,7 @@ import PostDetailConfirmDialog, {
 } from "./post-detail/PostDetailConfirmDialog";
 import PostDetailHeader from "./post-detail/PostDetailHeader";
 import PostDetailTableOfContents from "./post-detail/PostDetailTableOfContents";
-import { Comment, FeedMode, Post } from "../types";
+import { Comment, Post } from "../types";
 import { CommentSort } from "../services/comments/types";
 import { ValidationErrors } from "../services/comments/apiError";
 
@@ -32,7 +32,6 @@ interface PostDetailProps {
   comments: Comment[];
   isRead: boolean;
   reactionState: "like" | "dislike" | "none";
-  currentMode: FeedMode;
   isCommentsLoading: boolean;
   commentsHasNext: boolean;
   isCommentsLoadingMore: boolean;
@@ -76,7 +75,6 @@ export default function PostDetail({
   comments,
   isRead,
   reactionState,
-  currentMode,
   isCommentsLoading,
   commentsHasNext,
   isCommentsLoadingMore,
@@ -174,8 +172,6 @@ export default function PostDetail({
     <div className="min-h-screen bg-background">
       <Header
         onMenuClick={() => {}}
-        currentMode={currentMode}
-        onModeChange={() => {}}
       />
 
       <main className="mx-auto px-4 pt-8 pb-[calc(max(18rem,100vh)+env(safe-area-inset-bottom))] md:px-6 md:pt-12 md:pb-[calc(max(24rem,100vh)+env(safe-area-inset-bottom))]">

--- a/src/components/post-detail/PostDetailHeader.tsx
+++ b/src/components/post-detail/PostDetailHeader.tsx
@@ -11,7 +11,7 @@ import PostDetailMenuItemButton from "./PostDetailMenuItemButton";
 import UnblockActionButton from "../ui/UnblockActionButton";
 
 function buildTagRoute(tagId: string): string {
-  return `/?mode=user&tagIds=${encodeURIComponent(tagId)}`;
+  return `/?tagIds=${encodeURIComponent(tagId)}`;
 }
 
 interface PostDetailHeaderProps {

--- a/src/hooks/post-write/usePublishFlow.ts
+++ b/src/hooks/post-write/usePublishFlow.ts
@@ -4,6 +4,7 @@ import { InfiniteData, QueryClient, useMutation } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { usePathname, useRouter } from "../../i18n/navigation";
 import { redirectToOAuthLogin } from "../../lib/authRedirect";
+import { buildCommunityPostPath } from "../../lib/communityPostRoute";
 import { createPost, updatePost } from "../../services/posts";
 import { queryKeys } from "../../lib/queryKeys";
 import { DraftPostListResult } from "../../services/posts/types";
@@ -181,7 +182,11 @@ export function usePublishFlow({
         setSuccess(tPublish("published"));
       }
 
-      router.push("/");
+      router.push(buildCommunityPostPath({
+        fallbackName: result.data.authorName,
+        categoryPath: result.data.categoryPath,
+        postId: result.data.id,
+      }));
     },
     onError: (saveError, variables) => {
       const message = saveError instanceof Error ? saveError.message : "UNKNOWN";

--- a/src/hooks/post-write/usePublishFlow.ts
+++ b/src/hooks/post-write/usePublishFlow.ts
@@ -181,10 +181,7 @@ export function usePublishFlow({
         setSuccess(tPublish("published"));
       }
 
-      router.push({
-        pathname: "/",
-        query: { mode: "user" },
-      });
+      router.push("/");
     },
     onError: (saveError, variables) => {
       const message = saveError instanceof Error ? saveError.message : "UNKNOWN";

--- a/src/hooks/useFeedFilters.ts
+++ b/src/hooks/useFeedFilters.ts
@@ -2,22 +2,26 @@
 
 import { useMemo, useState } from "react";
 import { FEED_MODES } from "../constants/feed";
-import { FeedMode, FilterState, Post } from "../types";
+import { DateRange, FeedMode, FilterState, Post, SortOption } from "../types";
 import { PostListPeriod, PostListSort } from "../services/posts/types";
 
 interface UseFeedFiltersArgs {
   initialMode: FeedMode;
   initialSelectedTags?: string[];
+  initialDateRange?: DateRange;
+  initialSortBy?: SortOption;
 }
 
 export function useFeedFilters({
   initialMode,
   initialSelectedTags = [],
+  initialDateRange = "all",
+  initialSortBy = "latest",
 }: UseFeedFiltersArgs) {
   const [filterState, setFilterState] = useState<FilterState>({
     mode: initialMode,
-    dateRange: "all",
-    sortBy: "latest",
+    dateRange: initialDateRange,
+    sortBy: initialSortBy,
     searchUser: "",
     hideReadPosts: false,
     selectedTags: Array.from(new Set(initialSelectedTags.map((id) => id.toLowerCase()))),

--- a/src/hooks/usePostDetail.ts
+++ b/src/hooks/usePostDetail.ts
@@ -5,7 +5,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { useUser } from "./useUser";
 import { redirectToOAuthLogin } from "../lib/authRedirect";
-import { FEED_MODES } from "../constants/feed";
 import {
   deletePost,
   fetchPostDetailWithMeta,
@@ -20,7 +19,7 @@ import {
 } from "../services/users/follow";
 import { useUserBlockActions } from "./useUserBlockActions";
 import { type ToggleFollowResult, useFollowActions } from "./useFollowActions";
-import { FeedMode, Post } from "../types";
+import { Post } from "../types";
 import { queryKeys } from "../lib/queryKeys";
 import {
   calculateNextLikeCount,
@@ -40,7 +39,6 @@ export function usePostDetail(
   const t = useTranslations("PostDetailPage");
   const queryClient = useQueryClient();
   const { user } = useUser();
-  const currentMode: FeedMode = FEED_MODES.USER;
   const userId = user?.id ?? null;
   const { blockUser, isBlocking: isReporting } = useUserBlockActions(userId);
   const { toggleFollow, isPending: isFollowingUpdating } = useFollowActions();
@@ -520,7 +518,6 @@ export function usePostDetail(
     setPost,
     reactionState,
     isRead,
-    currentMode,
     isLoading,
     errorMessage,
     handleLike,

--- a/src/views/DraftPostsPage.tsx
+++ b/src/views/DraftPostsPage.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "../i18n/navigation";
 import Header from "../components/Header";
-import { FEED_MODES } from "../constants/feed";
 import { useDraftPosts } from "../hooks/useDraftPosts";
 import { useUser } from "../hooks/useUser";
 
@@ -58,8 +57,6 @@ export default function DraftPostsPage() {
     <div className="min-h-screen bg-background">
       <Header
         onMenuClick={() => {}}
-        currentMode={FEED_MODES.USER}
-        onModeChange={() => {}}
       />
 
       <main className="mx-auto w-full max-w-4xl px-4 py-6 md:py-8">

--- a/src/views/HomePage.tsx
+++ b/src/views/HomePage.tsx
@@ -8,11 +8,8 @@ import Header from "../components/Header";
 import Sidebar from "../components/Sidebar";
 import FilterBar from "../components/FilterBar";
 import CommunityFeedSection from "../components/feed/CommunityFeedSection";
-import CompanyFeedSection from "../components/feed/CompanyFeedSection";
 import { FEED_MODES } from "../constants/feed";
-import { FeedMode, FilterState } from "../types";
-import { DUMMY_TECH_BLOGS } from "../data/dummyData";
-import { useCompanyFeed } from "../hooks/useCompanyFeed";
+import { FilterState } from "../types";
 import { useFeedFilters } from "../hooks/useFeedFilters";
 import { useCommunityFeed } from "../hooks/useCommunityFeed";
 import { useTagNamesByIds } from "../hooks/useTagNamesByIds";
@@ -21,11 +18,7 @@ import { useUser } from "../hooks/useUser";
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-function HomeContent({
-  initialMode,
-}: {
-  initialMode: FeedMode;
-}) {
+function HomeContent() {
   const t = useTranslations("HomePage");
   const router = useRouter();
   const pathname = usePathname();
@@ -43,23 +36,17 @@ function HomeContent({
         .filter((tagId) => UUID_PATTERN.test(tagId)),
     [searchParams],
   );
-  const modeParam = searchParams.get("mode");
-  const modeFromUrl: FeedMode =
-    selectedTagIdsFromUrl.length > 0
-      ? FEED_MODES.USER
-      : modeParam === FEED_MODES.USER || modeParam === FEED_MODES.COMPANY
-        ? modeParam
-        : FEED_MODES.COMPANY;
-
   const {
     filterState,
     setFilterState,
-    handleModeChange,
     communityPeriod,
     communitySort,
     getVisiblePosts,
   } = useFeedFilters({
-    initialMode,
+    initialMode: FEED_MODES.USER,
+    initialSelectedTags: selectedTagIdsFromUrl,
+    initialDateRange: "7d",
+    initialSortBy: "views",
   });
 
   const syncTagsToUrl = useCallback(
@@ -71,23 +58,22 @@ function HomeContent({
         normalizedTagIds.length === selectedTagIdsFromUrl.length &&
         normalizedTagIds.every((tagId, index) => tagId === selectedTagIdsFromUrl[index]);
 
-      if (hasSameTags && modeParam === nextState.mode) {
+      if (hasSameTags && !searchParams.has("mode")) {
         return;
       }
 
       const nextParams = new URLSearchParams(searchParams.toString());
-      nextParams.set("mode", nextState.mode);
+      nextParams.delete("mode");
       nextParams.delete("tagIds");
 
-      if (nextState.mode === FEED_MODES.USER) {
-        normalizedTagIds.forEach((tagId) => {
-          nextParams.append("tagIds", tagId);
-        });
-      }
+      normalizedTagIds.forEach((tagId) => {
+        nextParams.append("tagIds", tagId);
+      });
 
-      router.replace(`${pathname}?${nextParams.toString()}`, { scroll: false });
+      const nextQuery = nextParams.toString();
+      router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
     },
-    [modeParam, pathname, router, searchParams, selectedTagIdsFromUrl],
+    [pathname, router, searchParams, selectedTagIdsFromUrl],
   );
 
   const handleFilterChange = useCallback(
@@ -105,32 +91,28 @@ function HomeContent({
 
   useEffect(() => {
     setFilterState((prev) => {
-      const hasSameMode = prev.mode === modeFromUrl;
       const hasSameTags =
         prev.selectedTags.length === selectedTagIdsFromUrl.length &&
         prev.selectedTags.every((tagId, index) => tagId === selectedTagIdsFromUrl[index]);
 
-      if (hasSameMode && hasSameTags) {
+      if (prev.mode === FEED_MODES.USER && hasSameTags) {
         return prev;
       }
 
       return {
         ...prev,
-        mode: modeFromUrl,
+        mode: FEED_MODES.USER,
         selectedTags: selectedTagIdsFromUrl,
       };
     });
-  }, [modeFromUrl, selectedTagIdsFromUrl, setFilterState]);
+  }, [selectedTagIdsFromUrl, setFilterState]);
 
   const communityFeed = useCommunityFeed({
-    enabled: filterState.mode === "user",
+    enabled: true,
     period: communityPeriod,
     sort: communitySort,
     tagIds: filterState.selectedTags,
     size: 20,
-  });
-  const companyFeed = useCompanyFeed({
-    enabled: filterState.mode === FEED_MODES.COMPANY,
   });
 
   const handleReadStatusChange = (postId: string, isRead: boolean) => {
@@ -153,22 +135,21 @@ function HomeContent({
     });
   };
 
-  const currentPosts =
-    filterState.mode === FEED_MODES.COMPANY
-      ? companyFeed.posts
-      : communityFeed.posts;
+  const currentUserId = user?.id;
   const visiblePosts = useMemo(() => {
-    const currentUserReadPosts = user?.id ? readPostIdsByUser[user.id] : undefined;
+    const currentUserReadPosts = currentUserId
+      ? readPostIdsByUser[currentUserId]
+      : undefined;
 
-    const mergedPosts = currentPosts.map((post) => ({
+    const mergedPosts = communityFeed.posts.map((post) => ({
       ...post,
       isRead:
-        Boolean(user?.id) &&
+        Boolean(currentUserId) &&
         (post.isRead || Boolean(currentUserReadPosts?.has(post.id))),
     }));
 
     return getVisiblePosts(mergedPosts);
-  }, [currentPosts, getVisiblePosts, readPostIdsByUser, user?.id]);
+  }, [communityFeed.posts, currentUserId, getVisiblePosts, readPostIdsByUser]);
 
   const { tagNameMap } = useTagNamesByIds(filterState.selectedTags);
   const selectedTagItems = useMemo(
@@ -193,8 +174,6 @@ function HomeContent({
     <div className="min-h-screen bg-background overflow-x-hidden">
       <Header
         onMenuClick={() => setIsMobileSidebarOpen(true)}
-        currentMode={filterState.mode}
-        onModeChange={handleModeChange}
       />
       <div className="md:flex max-w-[1400px] mx-auto">
         <Sidebar
@@ -203,47 +182,33 @@ function HomeContent({
           filterState={filterState}
           onFilterChange={handleFilterChange}
           availableTags={[]}
-          availableTechBlogs={DUMMY_TECH_BLOGS}
           isOpen={isMobileSidebarOpen}
           onClose={() => setIsMobileSidebarOpen(false)}
         />
         <main className="flex-1 md:max-w-[728px] mx-auto px-4 md:px-6 py-6">
-          {filterState.mode === "user" && (
-            <>
-              {selectedTagItems.length > 0 && (
-                <section className="mb-4">
-                  <p className="text-sm font-semibold text-foreground">
-                    {selectedTagSummary}
-                  </p>
-                </section>
-              )}
-
-              <FilterBar
-                filterState={filterState}
-                onFilterChange={handleFilterChange}
-              />
-            </>
+          {selectedTagItems.length > 0 && (
+            <section className="mb-4">
+              <p className="text-sm font-semibold text-foreground">
+                {selectedTagSummary}
+              </p>
+            </section>
           )}
 
-          {filterState.mode === "user" ? (
-            <CommunityFeedSection
-              posts={visiblePosts}
-              error={communityFeed.error}
-              hasNext={communityFeed.hasNext}
-              isLoading={communityFeed.isLoading}
-              isLoadingMore={communityFeed.isLoadingMore}
-              onLoadMore={communityFeed.loadMore}
-              onReadStatusChange={handleReadStatusChange}
-              currentUserId={user?.id}
-            />
-          ) : (
-            <CompanyFeedSection
-              posts={visiblePosts}
-              isLoading={companyFeed.isLoading}
-              onReadStatusChange={handleReadStatusChange}
-              currentUserId={user?.id}
-            />
-          )}
+          <FilterBar
+            filterState={filterState}
+            onFilterChange={handleFilterChange}
+          />
+
+          <CommunityFeedSection
+            posts={visiblePosts}
+            error={communityFeed.error}
+            hasNext={communityFeed.hasNext}
+            isLoading={communityFeed.isLoading}
+            isLoadingMore={communityFeed.isLoadingMore}
+            onLoadMore={communityFeed.loadMore}
+            onReadStatusChange={handleReadStatusChange}
+            currentUserId={currentUserId}
+          />
         </main>
       </div>
     </div>
@@ -251,24 +216,5 @@ function HomeContent({
 }
 
 export default function HomePage() {
-  const searchParams = useSearchParams();
-  const modeParam = searchParams.get("mode");
-  const initialTagIds = searchParams
-    .getAll("tagIds")
-    .map((tagId) => tagId.trim().toLowerCase())
-    .filter((tagId) => UUID_PATTERN.test(tagId));
-
-  const initialMode: FeedMode =
-    initialTagIds.length > 0
-      ? FEED_MODES.USER
-      : modeParam === FEED_MODES.USER || modeParam === FEED_MODES.COMPANY
-        ? modeParam
-        : FEED_MODES.COMPANY;
-
-  return (
-    <HomeContent
-      key={initialMode}
-      initialMode={initialMode}
-    />
-  );
+  return <HomeContent />;
 }

--- a/src/views/PostDetailPage.tsx
+++ b/src/views/PostDetailPage.tsx
@@ -39,7 +39,6 @@ export default function PostDetailPage() {
     setPost,
     reactionState,
     isRead,
-    currentMode,
     isLoading,
     errorMessage,
     handleLike,
@@ -91,8 +90,6 @@ export default function PostDetailPage() {
       <div className="min-h-screen bg-background">
         <Header
           onMenuClick={() => {}}
-          currentMode={currentMode}
-          onModeChange={() => {}}
         />
         <div className="flex items-center justify-center py-20">
           <p className="text-lg text-muted-foreground">{t("loading")}</p>
@@ -107,8 +104,6 @@ export default function PostDetailPage() {
         <div className="min-h-screen bg-background">
           <Header
             onMenuClick={() => {}}
-            currentMode={currentMode}
-            onModeChange={() => {}}
           />
           <div className="flex items-center justify-center py-20">
             <p className="text-lg text-muted-foreground">{t("loading")}</p>
@@ -121,8 +116,6 @@ export default function PostDetailPage() {
       <div className="min-h-screen bg-background">
         <Header
           onMenuClick={() => {}}
-          currentMode={currentMode}
-          onModeChange={() => {}}
         />
         <div className="flex items-center justify-center py-20">
           <p className="text-lg text-muted-foreground">
@@ -159,7 +152,6 @@ export default function PostDetailPage() {
         comments={comments}
         isRead={isRead}
         reactionState={reactionState}
-        currentMode={currentMode}
         isCommentsLoading={isCommentsLoading}
         commentsHasNext={commentsHasNext}
         isCommentsLoadingMore={isCommentsLoadingMore}
@@ -192,10 +184,7 @@ export default function PostDetailPage() {
         onDelete={async () => {
           const deleted = await handleDelete();
           if (deleted) {
-            router.replace({
-              pathname: "/",
-              query: { mode: "user" },
-            });
+            router.replace("/");
             router.refresh();
           }
           return deleted;

--- a/src/views/SearchPage.tsx
+++ b/src/views/SearchPage.tsx
@@ -7,8 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "../i18n/navigation";
 import Header from "../components/Header";
 import PostCard from "../components/PostCard";
-import { FEED_MODES } from "../constants/feed";
-import { FeedMode, Post } from "../types";
+import { Post } from "../types";
 import { DUMMY_COMPANY_POSTS } from "../data/dummyData";
 import { fetchCommunityPostList } from "../services/posts";
 
@@ -70,7 +69,6 @@ function SearchPageContent() {
 
   const [inputValue, setInputValue] = useState(initialQuery);
   const [committedQuery, setCommittedQuery] = useState(initialQuery);
-  const [mode, setMode] = useState<FeedMode>(FEED_MODES.COMPANY);
 
   useEffect(() => {
     setInputValue(initialQuery);
@@ -108,7 +106,7 @@ function SearchPageContent() {
 
   return (
     <div className="min-h-screen bg-background">
-      <Header currentMode={mode} onModeChange={setMode} />
+      <Header />
       <div className="max-w-[800px] mx-auto px-4 md:px-6 py-6">
         <form onSubmit={handleSubmit} className="mb-6">
           <div className="relative">

--- a/src/views/UserDetailPage.tsx
+++ b/src/views/UserDetailPage.tsx
@@ -19,8 +19,6 @@ import UserFollowListModal, {
   FollowListTab,
 } from "../components/user/UserFollowListModal";
 import CommunityFeedSection from "../components/feed/CommunityFeedSection";
-import { FEED_MODES } from "../constants/feed";
-import { FeedMode } from "../types";
 import { PostListPeriod, PostListSort, UserCategory } from "../services/posts/types";
 import { fetchMyBans, isBanApiError } from "../services/users/ban";
 import {
@@ -259,7 +257,6 @@ function UserDetailPageContent() {
   const userId = typeof params.id === "string" ? params.id : "";
   const isBlockedIntent = searchParams.get("blocked") === "1";
   const requestedCategoryPath = searchParams.get("categoryPath")?.trim() || null;
-  const [currentMode, setCurrentMode] = useState<FeedMode>(FEED_MODES.USER);
 
   const [period, setPeriod] = useState<PostListPeriod>("ALL");
   const [sort, setSort] = useState<PostListSort>("LATEST");
@@ -700,8 +697,6 @@ function UserDetailPageContent() {
   return (
     <div className="min-h-screen bg-background">
       <Header
-        currentMode={currentMode}
-        onModeChange={setCurrentMode}
         onMenuClick={() => setIsMobileCategorySidebarOpen(true)}
       />
 

--- a/src/views/WritePostPage.tsx
+++ b/src/views/WritePostPage.tsx
@@ -262,10 +262,7 @@ function WritePostPageContent() {
               isPublishActionDisabled={isPublishActionDisabled}
               draftCountLabel={draftBootstrap.draftCountLabel}
               showDraftActions={!isPostEditMode}
-              onGoBack={() => router.push({
-                pathname: "/",
-                query: { mode: "user" },
-              })}
+              onGoBack={() => router.push("/")}
               onSaveDraft={() => void publishFlow.handleSubmit("DRAFT")}
               onOpenPublishModal={publishFlow.openPublishModal}
               onGoDraftList={() => router.push("/post/drafts")}


### PR DESCRIPTION
## 어떤 작업인가요?
- 메인 화면을 커뮤니티 피드 중심으로 정리하고, 첫 진입 시 7일 조회순 피드가 보이도록 기본 필터를 조정했습니다.

## 어떻게 해결했나요?
**커뮤니티 홈 고정**
- 홈에서 기업 블로그 피드 분기를 제거하고 커뮤니티 피드만 렌더링하도록 정리했습니다.
- `mode=user` 쿼리에 의존하던 홈 이동과 태그 링크를 기본 커뮤니티 경로 기준으로 정리했습니다.

**네비게이션 정리**
- 헤더의 기업 블로그/커뮤니티 모드 전환 UI를 제거했습니다.
- 모바일 바텀 네비의 기업 블로그 항목을 커뮤니티 홈 링크로 대체했습니다.

**필터 기본값 및 순서 조정**
- 홈 기본 필터를 7일 조회순으로 설정했습니다.
- 정렬 옵션 노출 순서를 조회순, 추천순, 최신순, 댓글순으로 변경했습니다.

## 중요한 변경 사항은 무엇인가요?
### 홈 피드 기준 변경

**메인 피드 커뮤니티 고정**
- **변경 이유**: 메인 화면을 커뮤니티 중심으로 제공하기 위해 기업 블로그 모드 진입면을 제거했습니다.
- **수정 파일**: `src/views/HomePage.tsx`, `src/components/Header.tsx`, `src/components/BottomNav.tsx`

**기본 필터 적용**
- **변경 이유**: 첫 진입 시 최근 7일간 조회순 콘텐츠가 우선 노출되도록 기본 정렬을 맞췄습니다.
- **수정 파일**: `src/views/HomePage.tsx`, `src/hooks/useFeedFilters.ts`, `src/components/FilterBar.tsx`

**잔여 홈 이동 쿼리 정리**
- **변경 이유**: 홈이 커뮤니티로 고정되면서 불필요해진 `mode=user` 쿼리 의존을 제거했습니다.
- **수정 파일**: `src/components/PostCard.tsx`, `src/components/post-detail/PostDetailHeader.tsx`, `src/views/WritePostPage.tsx`, `src/hooks/post-write/usePublishFlow.ts`

Co-Authored-By: Codex <codex@openai.com>
