### PR TITLE
feat(post-detail): 게시물 상세에서 mermaid 다이어그램 렌더링 지원

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { ReactNode, useMemo } from "react";
+import { isValidElement, ReactElement, ReactNode, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { ALLOWED_HTML_TAGS } from "../constants/markdownAllowedHtml";
+import MermaidBlock from "./MermaidBlock";
 
 export interface TableOfContentsHeading {
   id: string;
@@ -56,6 +57,22 @@ function createHeadingId(text: string, counts: Map<string, number>): string {
   }
 
   return `${normalizedText}-${currentCount + 1}`;
+}
+
+const MERMAID_LANGUAGE_CLASS_PATTERN = /(?:^|\s)language-mermaid(?:\s|$)/;
+
+function findFirstReactElement(node: ReactNode): ReactElement | null {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findFirstReactElement(child);
+      if (found) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  return isValidElement(node) ? node : null;
 }
 
 function extractTextFromReactNode(node: ReactNode): string {
@@ -167,6 +184,25 @@ export default function MarkdownRenderer({
     <div className="markdown-content">
       <ReactMarkdown
         components={{
+          pre: ({ children, ...props }) => {
+            const codeElement = findFirstReactElement(children);
+            const codeClassName =
+              codeElement && typeof codeElement.props === "object" && codeElement.props !== null
+                ? (codeElement.props as { className?: unknown }).className
+                : undefined;
+
+            if (
+              codeElement &&
+              typeof codeClassName === "string" &&
+              MERMAID_LANGUAGE_CLASS_PATTERN.test(codeClassName)
+            ) {
+              const codeChildren = (codeElement.props as { children?: ReactNode }).children;
+              const rawCode = extractTextFromReactNode(codeChildren);
+              return <MermaidBlock code={rawCode} />;
+            }
+
+            return <pre {...props}>{children}</pre>;
+          },
           img: ({ src, alt, ...props }) => {
             if (typeof src !== "string" || src.trim().length === 0) {
               return null;
@@ -313,6 +349,63 @@ export default function MarkdownRenderer({
           background: transparent;
           padding: 0;
           font-family: var(--font-app-mono);
+        }
+
+        /* Mermaid 다이어그램 블록 */
+        .markdown-content .mermaid-block {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          margin: 1.5rem 0;
+          padding: 1rem;
+          background-color: var(--background);
+          border: 1px solid var(--border);
+          border-radius: 8px;
+          overflow-x: auto;
+        }
+
+        .markdown-content .mermaid-block svg {
+          max-width: 100%;
+          height: auto;
+        }
+
+        .markdown-content .mermaid-block-loading {
+          display: block;
+          color: var(--muted-foreground);
+          font-family: var(--font-app-mono);
+          font-size: 0.875rem;
+        }
+
+        .markdown-content .mermaid-block-loading pre {
+          background: transparent;
+          color: inherit;
+          padding: 0;
+          margin: 0;
+        }
+
+        .markdown-content .mermaid-block-error {
+          display: block;
+          background-color: color-mix(in srgb, var(--destructive, #ef4444) 8%, transparent);
+          border-color: color-mix(in srgb, var(--destructive, #ef4444) 40%, var(--border));
+          color: var(--foreground);
+        }
+
+        .markdown-content .mermaid-block-error-title {
+          font-weight: 600;
+          margin-bottom: 0.25rem;
+          color: var(--destructive, #ef4444);
+        }
+
+        .markdown-content .mermaid-block-error-message {
+          font-size: 0.875rem;
+          margin-bottom: 0.75rem;
+          color: var(--muted-foreground);
+        }
+
+        .markdown-content .mermaid-block-source {
+          margin: 0;
+          background-color: var(--muted);
+          color: var(--foreground);
         }
 
         /* 인용문 */

--- a/src/components/MermaidBlock.entities.test.mjs
+++ b/src/components/MermaidBlock.entities.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const mermaidBlockSource = readFileSync(
+  new URL("./MermaidBlock.tsx", import.meta.url),
+  "utf8",
+);
+
+test("mermaid block decodes named html entities before rendering", () => {
+  assert.match(mermaidBlockSource, /function decodeMermaidEntities/);
+  assert.match(mermaidBlockSource, /"&amp;": "&"/);
+  assert.match(mermaidBlockSource, /"&lt;": "<"/);
+  assert.match(mermaidBlockSource, /"&gt;": ">"/);
+  assert.match(mermaidBlockSource, /"&quot;": '"'/);
+  assert.match(mermaidBlockSource, /"&apos;": "'"/);
+  assert.match(mermaidBlockSource, /"&nbsp;": " "/);
+});
+
+test("mermaid block uses decoded code for rendering, error fallback, and loading view", () => {
+  assert.match(
+    mermaidBlockSource,
+    /const decodedCode = useMemo\(\(\) => decodeMermaidEntities\(code\), \[code\]\);/,
+  );
+  assert.match(
+    mermaidBlockSource,
+    /const trimmedCode = decodedCode\.trim\(\);/,
+  );
+  assert.match(mermaidBlockSource, /\[decodedCode, isDarkTheme, sanitizedId\]/);
+  const decodedUsages = mermaidBlockSource.match(/<code>\{decodedCode\}<\/code>/g) ?? [];
+  assert.equal(decodedUsages.length, 2, "decodedCode should back both fallback panels");
+});
+
+test("decoder also supports numeric and hexadecimal html entities", () => {
+  assert.match(
+    mermaidBlockSource,
+    /\(\?:amp\|lt\|gt\|quot\|apos\|nbsp\|#\(\\d\+\)\|#x\(\[0-9a-fA-F\]\+\)\);/,
+  );
+  assert.match(mermaidBlockSource, /String\.fromCodePoint\(codePoint\)/);
+});

--- a/src/components/MermaidBlock.entities.test.mjs
+++ b/src/components/MermaidBlock.entities.test.mjs
@@ -38,3 +38,17 @@ test("decoder also supports numeric and hexadecimal html entities", () => {
   );
   assert.match(mermaidBlockSource, /String\.fromCodePoint\(codePoint\)/);
 });
+
+test("decoder validates numeric html entities before converting code points", () => {
+  assert.match(mermaidBlockSource, /const MAX_UNICODE_CODE_POINT = 0x10ffff;/);
+  assert.match(mermaidBlockSource, /Number\.isInteger\(codePoint\)/);
+  assert.match(mermaidBlockSource, /codePoint > MAX_UNICODE_CODE_POINT/);
+
+  const guardedDecodes =
+    mermaidBlockSource.match(/decodeCodePointEntity\(codePoint, match\)/g) ?? [];
+  assert.equal(
+    guardedDecodes.length,
+    2,
+    "decimal and hexadecimal entities should both use the guarded decoder",
+  );
+});

--- a/src/components/MermaidBlock.tsx
+++ b/src/components/MermaidBlock.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { useTheme } from "./ThemeProvider";
+
+interface MermaidBlockProps {
+  code: string;
+}
+
+const NAMED_HTML_ENTITY_MAP: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&apos;": "'",
+  "&nbsp;": " ",
+};
+
+/**
+ * mermaid 입력은 마크다운 렌더링 파이프라인에서 HTML 엔티티로 치환되어 들어올 수 있다.
+ * `--&gt;` 같은 토큰이 그대로 파서로 전달되면 mermaid가 실패하므로,
+ * 다이어그램에 한해 일반적인 엔티티만 원래 문자로 되돌린다.
+ * 단일 패스로 처리해 이중 인코딩을 임의로 풀지 않는다.
+ */
+function decodeMermaidEntities(input: string): string {
+  return input.replace(
+    /&(?:amp|lt|gt|quot|apos|nbsp|#(\d+)|#x([0-9a-fA-F]+));/g,
+    (match, decimalCode?: string, hexCode?: string) => {
+      if (decimalCode) {
+        const codePoint = Number.parseInt(decimalCode, 10);
+        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match;
+      }
+
+      if (hexCode) {
+        const codePoint = Number.parseInt(hexCode, 16);
+        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match;
+      }
+
+      return NAMED_HTML_ENTITY_MAP[match] ?? match;
+    },
+  );
+}
+
+/**
+ * mermaid 코드 블록을 SVG 다이어그램으로 렌더링한다.
+ * mermaid 모듈은 window 의존성이 있어 클라이언트에서만 동적으로 로드한다.
+ * 라이트/다크 테마에 맞춰 재렌더링하며, 실패 시 원본 코드를 그대로 노출한다.
+ */
+export default function MermaidBlock({ code }: MermaidBlockProps) {
+  const reactId = useId();
+  const sanitizedId = useMemo(
+    () => `mermaid-${reactId.replace(/[^a-zA-Z0-9-]/g, "")}`,
+    [reactId],
+  );
+  const { resolvedTheme } = useTheme();
+  const isDarkTheme = resolvedTheme === "dark";
+  const [svg, setSvg] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const renderTokenRef = useRef(0);
+  const decodedCode = useMemo(() => decodeMermaidEntities(code), [code]);
+
+  useEffect(() => {
+    const trimmedCode = decodedCode.trim();
+    if (trimmedCode.length === 0) {
+      setSvg(null);
+      setErrorMessage(null);
+      return;
+    }
+
+    const currentToken = ++renderTokenRef.current;
+
+    const renderDiagram = async () => {
+      try {
+        const mermaidModule = await import("mermaid");
+        const mermaid = mermaidModule.default;
+
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: isDarkTheme ? "dark" : "default",
+          securityLevel: "strict",
+          fontFamily:
+            "var(--font-app-mono, ui-monospace), SFMono-Regular, Menlo, monospace",
+        });
+
+        const renderId = `${sanitizedId}-${currentToken}`;
+        const { svg: renderedSvg } = await mermaid.render(renderId, trimmedCode);
+
+        if (renderTokenRef.current !== currentToken) {
+          return;
+        }
+
+        setSvg(renderedSvg);
+        setErrorMessage(null);
+      } catch (error) {
+        if (renderTokenRef.current !== currentToken) {
+          return;
+        }
+
+        const message =
+          error instanceof Error ? error.message : "Mermaid 렌더링에 실패했습니다.";
+        setSvg(null);
+        setErrorMessage(message);
+      }
+    };
+
+    renderDiagram();
+
+    return () => {
+      renderTokenRef.current += 1;
+    };
+  }, [decodedCode, isDarkTheme, sanitizedId]);
+
+  if (errorMessage) {
+    return (
+      <div className="mermaid-block mermaid-block-error" role="alert">
+        <p className="mermaid-block-error-title">Mermaid 렌더링 오류</p>
+        <p className="mermaid-block-error-message">{errorMessage}</p>
+        <pre className="mermaid-block-source">
+          <code>{decodedCode}</code>
+        </pre>
+      </div>
+    );
+  }
+
+  if (svg) {
+    return (
+      <div
+        className="mermaid-block"
+        role="img"
+        aria-label="Mermaid diagram"
+        dangerouslySetInnerHTML={{ __html: svg }}
+      />
+    );
+  }
+
+  return (
+    <div className="mermaid-block mermaid-block-loading" aria-busy="true">
+      <pre>
+        <code>{decodedCode}</code>
+      </pre>
+    </div>
+  );
+}
+
+export { decodeMermaidEntities };

--- a/src/components/MermaidBlock.tsx
+++ b/src/components/MermaidBlock.tsx
@@ -16,6 +16,20 @@ const NAMED_HTML_ENTITY_MAP: Record<string, string> = {
   "&nbsp;": " ",
 };
 
+const MAX_UNICODE_CODE_POINT = 0x10ffff;
+
+function decodeCodePointEntity(codePoint: number, fallback: string): string {
+  if (
+    !Number.isInteger(codePoint) ||
+    codePoint < 0 ||
+    codePoint > MAX_UNICODE_CODE_POINT
+  ) {
+    return fallback;
+  }
+
+  return String.fromCodePoint(codePoint);
+}
+
 /**
  * mermaid 입력은 마크다운 렌더링 파이프라인에서 HTML 엔티티로 치환되어 들어올 수 있다.
  * `--&gt;` 같은 토큰이 그대로 파서로 전달되면 mermaid가 실패하므로,
@@ -28,12 +42,12 @@ function decodeMermaidEntities(input: string): string {
     (match, decimalCode?: string, hexCode?: string) => {
       if (decimalCode) {
         const codePoint = Number.parseInt(decimalCode, 10);
-        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match;
+        return decodeCodePointEntity(codePoint, match);
       }
 
       if (hexCode) {
         const codePoint = Number.parseInt(hexCode, 16);
-        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match;
+        return decodeCodePointEntity(codePoint, match);
       }
 
       return NAMED_HTML_ENTITY_MAP[match] ?? match;


### PR DESCRIPTION
## 관련 자료
- 없음

## 어떤 작업인가요?
- 게시물 상세 마크다운에서 ```mermaid 코드 블록을 SVG 다이어그램으로 렌더링하고, HTML 엔티티로 치환된 Mermaid 입력을 안전하게 복원합니다.
- 범위를 벗어난 숫자 HTML 엔티티가 포함되어도 마크다운 렌더링이 크래시하지 않도록 보강합니다.

## 어떻게 해결했나요?
**Mermaid 전용 렌더링 컴포넌트 추가**
- `MermaidBlock`에서 mermaid를 클라이언트에서 동적으로 로드하고, 라이트/다크 테마에 맞춰 초기화합니다.
- 렌더 토큰으로 오래된 비동기 렌더 결과를 무시하고, 로딩/에러 fallback에서 소스 코드를 표시합니다.

**마크다운 렌더러 연동**
- `MarkdownRenderer`의 `pre` 렌더러에서 `language-mermaid` fenced code block을 감지해 `MermaidBlock`으로 위임합니다.
- Mermaid 블록, 로딩 패널, 에러 패널 스타일을 기존 마크다운 렌더링 흐름에 맞춰 추가했습니다.

**HTML 엔티티 디코딩 안정화**
- mermaid 블록에 한해 named/numeric/hex HTML 엔티티를 단일 패스로 디코딩합니다.
- numeric entity는 유효한 Unicode code point 범위일 때만 `String.fromCodePoint`로 변환하고, 범위를 벗어나면 원문을 유지합니다.
- decimal/hex numeric entity가 모두 guarded decoder를 사용하도록 회귀 테스트를 추가했습니다.

## 중요한 변경 사항은 무엇인가요?
### Mermaid 렌더링 지원

**Mermaid 코드 블록 전용 컴포넌트 추가**
- **변경 이유**: 일반 코드 블록과 달리 Mermaid fenced block은 SVG 다이어그램으로 렌더링해야 하기 때문입니다.
- **수정 파일**: `src/components/MermaidBlock.tsx`

**MarkdownRenderer에서 Mermaid 블록 분기**
- **변경 이유**: 마크다운 렌더링 단계에서 `language-mermaid` 코드 블록만 기존 syntax highlight 대신 Mermaid 렌더러로 전달하기 위해서입니다.
- **수정 파일**: `src/components/MarkdownRenderer.tsx`

### 엔티티 디코딩 안정화

**HTML 엔티티 단일 패스 복원**
- **변경 이유**: 서버/마크다운 파이프라인에서 `--&gt;`처럼 치환된 Mermaid 문법이 parser에 그대로 전달되면 렌더링이 실패할 수 있기 때문입니다.
- **수정 파일**: `src/components/MermaidBlock.tsx`, `src/components/MermaidBlock.entities.test.mjs`

**범위 밖 numeric entity 보존**
- **변경 이유**: `&#9999999999;` 같은 값이 `String.fromCodePoint`에 전달되면 render 이전에 RangeError가 발생해 전체 마크다운 화면이 크래시할 수 있기 때문입니다.
- **수정 파일**: `src/components/MermaidBlock.tsx`, `src/components/MermaidBlock.entities.test.mjs`

Co-Authored-By: Codex <codex@openai.com>