### PR TITLE
fix(markdown): 코드 블록 하이라이트 토큰 보강

### DIFF
--- a/src/components/MarkdownRenderer.styles.test.mjs
+++ b/src/components/MarkdownRenderer.styles.test.mjs
@@ -48,3 +48,74 @@ test("markdown links show hover and keyboard focus states", () => {
     /\.markdown-content a:focus-visible\s*\{\s*outline:\s*2px solid var\(--color-blue-500\);\s*outline-offset:\s*2px;/m,
   );
 });
+
+test("code blocks keep highlight.js output readable", () => {
+  const codeBlockRuleMatch = markdownRendererSource.match(
+    /\.markdown-content pre code\.hljs,\s*\.markdown-content code\.hljs\s*\{(?<body>[\s\S]*?)\n\s*\}/m,
+  );
+
+  assert.ok(
+    codeBlockRuleMatch?.groups?.body,
+    "highlight.js code block CSS rule should exist",
+  );
+  assert.match(codeBlockRuleMatch.groups.body, /display:\s*block;/);
+  assert.match(codeBlockRuleMatch.groups.body, /overflow-x:\s*auto;/);
+  assert.match(codeBlockRuleMatch.groups.body, /background:\s*transparent;/);
+});
+
+test("code highlighting registers common markdown fence aliases", () => {
+  assert.match(
+    markdownRendererSource,
+    /javascript:\s*\["js",\s*"jsx"\]/,
+    "javascript aliases should support js and jsx fences",
+  );
+  assert.match(
+    markdownRendererSource,
+    /typescript:\s*\["ts",\s*"tsx"\]/,
+    "typescript aliases should support ts and tsx fences",
+  );
+  assert.match(
+    markdownRendererSource,
+    /\[rehypeHighlight,\s*codeHighlightOptions\]/,
+    "rehype-highlight should receive the alias options",
+  );
+});
+
+test("code highlighting covers common language token classes", () => {
+  [
+    ".hljs-keyword",
+    ".hljs-string",
+    ".hljs-number",
+    ".hljs-comment",
+    ".hljs-function",
+    ".hljs-title.function_",
+    ".hljs-class",
+    ".hljs-title.class_",
+    ".hljs-variable",
+    ".hljs-property",
+    ".hljs-built_in",
+    ".hljs-name",
+    ".hljs-tag",
+    ".hljs-attr",
+    ".hljs-attribute",
+    ".hljs-params",
+    ".hljs-literal",
+    ".hljs-meta",
+    ".hljs-type",
+    ".hljs-selector-id",
+    ".hljs-selector-class",
+    ".hljs-selector-attr",
+    ".hljs-selector-pseudo",
+    ".hljs-subst",
+    ".hljs-punctuation",
+    ".hljs-operator",
+    ".hljs-addition",
+    ".hljs-deletion",
+  ].forEach((selector) => {
+    assert.match(
+      markdownRendererSource,
+      new RegExp(escapeRegExp(selector)),
+      `${selector} should have an explicit markdown code highlight style`,
+    );
+  });
+});

--- a/src/components/MarkdownRenderer.styles.test.mjs
+++ b/src/components/MarkdownRenderer.styles.test.mjs
@@ -76,6 +76,16 @@ test("code highlighting registers common markdown fence aliases", () => {
   );
   assert.match(
     markdownRendererSource,
+    /bash:\s*\["sh",\s*"zsh"\]/,
+    "bash aliases should support shell command fences without terminal transcripts",
+  );
+  assert.match(
+    markdownRendererSource,
+    /shell:\s*\["terminal",\s*"console"\]/,
+    "shell aliases should preserve terminal transcript fences",
+  );
+  assert.match(
+    markdownRendererSource,
     /\[rehypeHighlight,\s*codeHighlightOptions\]/,
     "rehype-highlight should receive the alias options",
   );

--- a/src/components/MarkdownRenderer.styles.test.mjs
+++ b/src/components/MarkdownRenderer.styles.test.mjs
@@ -49,6 +49,22 @@ test("markdown links show hover and keyboard focus states", () => {
   );
 });
 
+test("markdown blockquotes keep consecutive and nested quotes grouped", () => {
+  const blockquoteRuleBody = getCssRuleBody(".markdown-content blockquote");
+  const blockquoteParagraphRuleBody = getCssRuleBody(".markdown-content blockquote p");
+  const nestedBlockquoteRuleBody = getCssRuleBody(".markdown-content blockquote blockquote");
+
+  assert.match(blockquoteRuleBody, /border-left:\s*4px solid var\(--border\);/);
+  assert.match(blockquoteRuleBody, /padding-left:\s*1rem;/);
+  assert.match(blockquoteParagraphRuleBody, /margin-bottom:\s*0\.5rem;/);
+  assert.match(
+    markdownRendererSource,
+    /\.markdown-content blockquote p:last-child,\s*\.markdown-content blockquote > :last-child\s*\{(?<body>[\s\S]*?)margin-bottom:\s*0;/m,
+  );
+  assert.match(nestedBlockquoteRuleBody, /margin:\s*0\.5rem 0;/);
+  assert.match(nestedBlockquoteRuleBody, /border-left-color:\s*var\(--muted-foreground\);/);
+});
+
 test("code blocks keep highlight.js output readable", () => {
   const codeBlockRuleMatch = markdownRendererSource.match(
     /\.markdown-content pre code\.hljs,\s*\.markdown-content code\.hljs\s*\{(?<body>[\s\S]*?)\n\s*\}/m,

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -152,7 +152,8 @@ const codeHighlightOptions = {
   aliases: {
     javascript: ["js", "jsx"],
     typescript: ["ts", "tsx"],
-    bash: ["sh", "zsh", "terminal", "console"],
+    bash: ["sh", "zsh"],
+    shell: ["terminal", "console"],
     plaintext: ["text", "txt", "plain"],
   },
 } as const;

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -148,6 +148,15 @@ const sanitizedSchema = {
   },
 } as const;
 
+const codeHighlightOptions = {
+  aliases: {
+    javascript: ["js", "jsx"],
+    typescript: ["ts", "tsx"],
+    bash: ["sh", "zsh", "terminal", "console"],
+    plaintext: ["text", "txt", "plain"],
+  },
+} as const;
+
 /**
  * 마크다운을 화이트리스트 기반으로 렌더링하는 컴포넌트
  * - GitHub Flavored Markdown 지원
@@ -244,7 +253,11 @@ export default function MarkdownRenderer({
           },
         }}
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizedSchema], rehypeHighlight]}
+        rehypePlugins={[
+          rehypeRaw,
+          [rehypeSanitize, sanitizedSchema],
+          [rehypeHighlight, codeHighlightOptions],
+        ]}
       >
         {content}
       </ReactMarkdown>
@@ -486,44 +499,96 @@ export default function MarkdownRenderer({
         }
 
         /* highlight.js 코드 하이라이팅 - VS Code Dark+ 스타일 */
-        .hljs-keyword {
+        .markdown-content pre code.hljs,
+        .markdown-content code.hljs {
+          display: block;
+          overflow-x: auto;
+          color: #d4d4d4;
+          background: transparent;
+        }
+
+        .hljs {
+          color: #d4d4d4;
+        }
+        .hljs-keyword,
+        .hljs-selector-tag,
+        .hljs-doctag {
           color: #569cd6;
         }
-        .hljs-string {
+        .hljs-string,
+        .hljs-regexp,
+        .hljs-template-variable {
           color: #ce9178;
         }
-        .hljs-number {
+        .hljs-number,
+        .hljs-symbol,
+        .hljs-bullet {
           color: #b5cea8;
         }
-        .hljs-comment {
+        .hljs-comment,
+        .hljs-quote {
           color: #6a9955;
         }
-        .hljs-function {
+        .hljs-function,
+        .hljs-title.function_ {
           color: #dcdcaa;
         }
-        .hljs-class {
+        .hljs-class,
+        .hljs-title.class_,
+        .hljs-section {
           color: #4ec9b0;
         }
-        .hljs-variable {
+        .hljs-variable,
+        .hljs-variable.language_,
+        .hljs-property {
           color: #9cdcfe;
         }
-        .hljs-built_in {
+        .hljs-built_in,
+        .hljs-name,
+        .hljs-tag {
           color: #4fc1ff;
         }
-        .hljs-attr {
+        .hljs-attr,
+        .hljs-attribute {
           color: #9cdcfe;
         }
-        .hljs-params {
-          color: #9cdcfe;
-        }
+        .hljs-params,
         .hljs-title {
-          color: #dcdcaa;
+          color: #9cdcfe;
         }
-        .hljs-literal {
+        .hljs-literal,
+        .hljs-meta,
+        .hljs-meta .hljs-keyword {
           color: #569cd6;
         }
-        .hljs-type {
+        .hljs-type,
+        .hljs-selector-id,
+        .hljs-selector-class,
+        .hljs-selector-attr,
+        .hljs-selector-pseudo {
           color: #4ec9b0;
+        }
+        .hljs-selector-tag {
+          color: #d7ba7d;
+        }
+        .hljs-subst,
+        .hljs-punctuation,
+        .hljs-operator {
+          color: #d4d4d4;
+        }
+        .hljs-addition {
+          color: #b5cea8;
+          background-color: rgba(46, 160, 67, 0.18);
+        }
+        .hljs-deletion {
+          color: #ce9178;
+          background-color: rgba(248, 81, 73, 0.18);
+        }
+        .hljs-emphasis {
+          font-style: italic;
+        }
+        .hljs-strong {
+          font-weight: 700;
         }
       `}</style>
     </div>

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -431,6 +431,20 @@ export default function MarkdownRenderer({
           font-style: italic;
         }
 
+        .markdown-content blockquote p {
+          margin-bottom: 0.5rem;
+        }
+
+        .markdown-content blockquote p:last-child,
+        .markdown-content blockquote > :last-child {
+          margin-bottom: 0;
+        }
+
+        .markdown-content blockquote blockquote {
+          margin: 0.5rem 0;
+          border-left-color: var(--muted-foreground);
+        }
+
         /* 링크 */
         .markdown-content a {
           color: var(--color-blue-500);


### PR DESCRIPTION
## 어떤 작업인가요?

- 게시물 상세와 작성 미리보기에서 마크다운 코드 블록의 언어별 하이라이트가 더 안정적으로 보이도록 개선합니다.

## 어떻게 해결했나요?

**코드 fence alias 보강**
- `js`, `jsx`, `ts`, `tsx`, `sh`, `zsh` 등 작성자가 자주 쓰는 fence 이름을 `rehype-highlight` alias로 연결했습니다.
- `plaintext` 계열 alias도 추가해 일반 텍스트 코드 블록이 의도대로 처리되게 했습니다.

**highlight.js 토큰 스타일 확장**
- JS/TS/HTML/CSS/JSON/Bash/Python 등에서 자주 나오는 `hljs-*` 토큰 스타일을 보강했습니다.
- 코드 블록 내부 `code.hljs` 기본 표시 규칙을 추가해 배경과 overflow가 안정적으로 유지되도록 했습니다.

**회귀 테스트 추가**
- 코드 블록 기본 스타일, alias 설정, 주요 토큰 클래스 스타일이 유지되는지 소스 기반 테스트를 추가했습니다.

## 중요한 변경 사항은 무엇인가요?

### 마크다운 코드 하이라이트 개선

**언어 alias 지원 추가**
- **변경 이유**: `tsx`, `jsx`처럼 실제 게시물에서 자주 쓰는 fence 이름이 기본 등록 언어와 맞지 않으면 하이라이트가 적용되지 않을 수 있습니다.
- **수정 파일**: `src/components/MarkdownRenderer.tsx`

**토큰 색상 커버리지 확장**
- **변경 이유**: highlight.js가 언어별로 다양한 토큰 클래스를 출력하므로 일부 언어에서 색상이 누락될 수 있습니다.
- **수정 파일**: `src/components/MarkdownRenderer.tsx`

**하이라이트 회귀 테스트 추가**
- **변경 이유**: 렌더러 스타일 변경 중 코드 하이라이트 관련 설정과 CSS가 빠지는 일을 방지합니다.
- **수정 파일**: `src/components/MarkdownRenderer.styles.test.mjs`

Co-Authored-By: Codex <codex@openai.com>