### PR TITLE
feat(markdown): mermaid 다이어그램 확장 뷰어 추가

### DIFF
--- a/src/components/MarkdownRenderer.styles.test.mjs
+++ b/src/components/MarkdownRenderer.styles.test.mjs
@@ -82,15 +82,16 @@ test("markdown renderer restores encoded blockquote markers before parsing", () 
   assert.match(markdownRendererSource, /\{normalizedContent\}/);
 });
 
-test("mermaid iframe viewers have expandable styles", () => {
+test("mermaid viewers have direct render and full-screen dialog styles", () => {
   [
     ".markdown-content .mermaid-block-viewer",
-    ".markdown-content .render-viewer",
-    ".markdown-content .mermaid-block-frame",
+    ".markdown-content .mermaid-block-content",
     ".markdown-content .mermaid-block-expand-button",
     ".markdown-content .mermaid-block-expanded",
     ".markdown-content .mermaid-block-expanded-toolbar",
-    ".markdown-content .mermaid-block-expanded-frame",
+    ".markdown-content .mermaid-block-expanded-canvas",
+    ".markdown-content .mermaid-block-expanded-canvas-dragging",
+    ".markdown-content .mermaid-block-expanded-content",
     ".markdown-content .mermaid-block-zoom-button",
     ".markdown-content .mermaid-block-zoom-value",
   ].forEach((selector) => {
@@ -100,6 +101,13 @@ test("mermaid iframe viewers have expandable styles", () => {
       `${selector} should have an explicit markdown mermaid viewer style`,
     );
   });
+
+  const expandedRuleBody = getCssRuleBody(".markdown-content .mermaid-block-expanded");
+  assert.match(expandedRuleBody, /position:\s*fixed;/);
+  assert.match(expandedRuleBody, /inset:\s*0;/);
+  assert.match(expandedRuleBody, /z-index:\s*1000;/);
+  assert.match(expandedRuleBody, /width:\s*100vw;/);
+  assert.match(expandedRuleBody, /height:\s*100dvh;/);
 });
 
 test("code blocks keep highlight.js output readable", () => {

--- a/src/components/MarkdownRenderer.styles.test.mjs
+++ b/src/components/MarkdownRenderer.styles.test.mjs
@@ -65,6 +65,34 @@ test("markdown blockquotes keep consecutive and nested quotes grouped", () => {
   assert.match(nestedBlockquoteRuleBody, /border-left-color:\s*var\(--muted-foreground\);/);
 });
 
+test("markdown renderer restores encoded blockquote markers before parsing", () => {
+  assert.match(markdownRendererSource, /const BLOCKQUOTE_MARKER_ENTITY_SEQUENCE_PATTERN =/);
+  assert.match(markdownRendererSource, /const BLOCKQUOTE_MARKER_ENTITY_PATTERN =/);
+  assert.match(markdownRendererSource, /function normalizeMarkdownSyntaxEntities\(content: string\): string/);
+  assert.match(
+    markdownRendererSource,
+    /markerSequence\.replace\(BLOCKQUOTE_MARKER_ENTITY_PATTERN,\s*">"\)/,
+  );
+  assert.match(markdownRendererSource, /\{normalizedContent\}/);
+});
+
+test("mermaid iframe viewers have expandable styles", () => {
+  [
+    ".markdown-content .mermaid-block-viewer",
+    ".markdown-content .render-viewer",
+    ".markdown-content .mermaid-block-frame",
+    ".markdown-content .mermaid-block-expand-button",
+    ".markdown-content .mermaid-block-expanded",
+    ".markdown-content .mermaid-block-expanded-frame",
+  ].forEach((selector) => {
+    assert.match(
+      markdownRendererSource,
+      new RegExp(escapeRegExp(selector)),
+      `${selector} should have an explicit markdown mermaid viewer style`,
+    );
+  });
+});
+
 test("code blocks keep highlight.js output readable", () => {
   const codeBlockRuleMatch = markdownRendererSource.match(
     /\.markdown-content pre code\.hljs,\s*\.markdown-content code\.hljs\s*\{(?<body>[\s\S]*?)\n\s*\}/m,

--- a/src/components/MarkdownRenderer.styles.test.mjs
+++ b/src/components/MarkdownRenderer.styles.test.mjs
@@ -68,11 +68,17 @@ test("markdown blockquotes keep consecutive and nested quotes grouped", () => {
 test("markdown renderer restores encoded blockquote markers before parsing", () => {
   assert.match(markdownRendererSource, /const BLOCKQUOTE_MARKER_ENTITY_SEQUENCE_PATTERN =/);
   assert.match(markdownRendererSource, /const BLOCKQUOTE_MARKER_ENTITY_PATTERN =/);
+  assert.match(markdownRendererSource, /const FENCED_CODE_BLOCK_PATTERN =/);
+  assert.match(markdownRendererSource, /function restoreBlockquoteMarkerEntities\(line: string\): string/);
   assert.match(markdownRendererSource, /function normalizeMarkdownSyntaxEntities\(content: string\): string/);
   assert.match(
     markdownRendererSource,
-    /markerSequence\.replace\(BLOCKQUOTE_MARKER_ENTITY_PATTERN,\s*">"\)/,
+    /markerSequence\.replace\(BLOCKQUOTE_MARKER_ENTITY_PATTERN,\s*">"\)\}\$\{rest\}/,
   );
+  assert.match(markdownRendererSource, /let isInFencedCodeBlock = false;/);
+  assert.match(markdownRendererSource, /FENCED_CODE_BLOCK_PATTERN\.test\(line\)/);
+  assert.match(markdownRendererSource, /isInFencedCodeBlock = !isInFencedCodeBlock;/);
+  assert.match(markdownRendererSource, /if \(isInFencedCodeBlock\)/);
   assert.match(markdownRendererSource, /\{normalizedContent\}/);
 });
 
@@ -83,7 +89,10 @@ test("mermaid iframe viewers have expandable styles", () => {
     ".markdown-content .mermaid-block-frame",
     ".markdown-content .mermaid-block-expand-button",
     ".markdown-content .mermaid-block-expanded",
+    ".markdown-content .mermaid-block-expanded-toolbar",
     ".markdown-content .mermaid-block-expanded-frame",
+    ".markdown-content .mermaid-block-zoom-button",
+    ".markdown-content .mermaid-block-zoom-value",
   ].forEach((selector) => {
     assert.match(
       markdownRendererSource,

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -60,6 +60,9 @@ function createHeadingId(text: string, counts: Map<string, number>): string {
 }
 
 const MERMAID_LANGUAGE_CLASS_PATTERN = /(?:^|\s)language-mermaid(?:\s|$)/;
+const BLOCKQUOTE_MARKER_ENTITY_SEQUENCE_PATTERN =
+  /^([ \t]*)((?:&(?:gt|#62|#x3e);[ \t]*)+)/gim;
+const BLOCKQUOTE_MARKER_ENTITY_PATTERN = /&(?:gt|#62|#x3e);/gi;
 
 function findFirstReactElement(node: ReactNode): ReactElement | null {
   if (Array.isArray(node)) {
@@ -92,10 +95,19 @@ function extractTextFromReactNode(node: ReactNode): string {
   return "";
 }
 
+function normalizeMarkdownSyntaxEntities(content: string): string {
+  return content.replace(
+    BLOCKQUOTE_MARKER_ENTITY_SEQUENCE_PATTERN,
+    (_match, indentation: string, markerSequence: string) =>
+      `${indentation}${markerSequence.replace(BLOCKQUOTE_MARKER_ENTITY_PATTERN, ">")}`,
+  );
+}
+
 export function extractTableOfContents(content: string): TableOfContentsHeading[] {
   const headingCounts = new Map<string, number>();
+  const normalizedContent = normalizeMarkdownSyntaxEntities(content);
 
-  return content
+  return normalizedContent
     .split("\n")
     .map((line) => line.match(/^(#{1,3})\s+(.+)$/))
     .filter((match): match is RegExpMatchArray => Boolean(match))
@@ -168,7 +180,14 @@ export default function MarkdownRenderer({
   content,
   resolveImageSrc,
 }: MarkdownRendererProps) {
-  const tableOfContents = useMemo(() => extractTableOfContents(content), [content]);
+  const normalizedContent = useMemo(
+    () => normalizeMarkdownSyntaxEntities(content),
+    [content],
+  );
+  const tableOfContents = useMemo(
+    () => extractTableOfContents(normalizedContent),
+    [normalizedContent],
+  );
   const headingIdsByText = useMemo(() => {
     const nextHeadingIds = new Map<string, string[]>();
 
@@ -260,7 +279,7 @@ export default function MarkdownRenderer({
           [rehypeHighlight, codeHighlightOptions],
         ]}
       >
-        {content}
+        {normalizedContent}
       </ReactMarkdown>
 
       {/* 마크다운 스타일 */}
@@ -381,6 +400,82 @@ export default function MarkdownRenderer({
         .markdown-content .mermaid-block svg {
           max-width: 100%;
           height: auto;
+        }
+
+        .markdown-content .mermaid-block-viewer {
+          position: relative;
+          display: block;
+          padding: 0;
+          overflow: hidden;
+        }
+
+        .markdown-content .render-viewer {
+          display: block;
+          width: 100%;
+          border: 0;
+          background-color: var(--background);
+        }
+
+        .markdown-content .mermaid-block-frame {
+          min-height: min(70vh, 36rem);
+        }
+
+        .markdown-content .mermaid-block-expand-button,
+        .markdown-content .mermaid-block-close-button {
+          position: absolute;
+          z-index: 1;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 2rem;
+          height: 2rem;
+          border: 1px solid var(--border);
+          border-radius: 6px;
+          background-color: color-mix(in srgb, var(--background) 92%, transparent);
+          color: var(--foreground);
+          box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
+          transition:
+            background-color 0.2s ease,
+            color 0.2s ease;
+        }
+
+        .markdown-content .mermaid-block-expand-button {
+          top: 0.75rem;
+          right: 0.75rem;
+        }
+
+        .markdown-content .mermaid-block-expand-button:hover,
+        .markdown-content .mermaid-block-close-button:hover,
+        .markdown-content .mermaid-block-expand-button:focus-visible,
+        .markdown-content .mermaid-block-close-button:focus-visible {
+          background-color: var(--muted);
+          color: var(--foreground);
+        }
+
+        .markdown-content .mermaid-block-expand-button:focus-visible,
+        .markdown-content .mermaid-block-close-button:focus-visible {
+          outline: 2px solid var(--color-blue-500);
+          outline-offset: 2px;
+        }
+
+        .markdown-content .mermaid-block-expanded {
+          position: fixed;
+          inset: 0;
+          z-index: 80;
+          padding: 3.5rem 1rem 1rem;
+          background-color: color-mix(in srgb, var(--background) 96%, black 4%);
+        }
+
+        .markdown-content .mermaid-block-close-button {
+          top: 1rem;
+          right: 1rem;
+        }
+
+        .markdown-content .mermaid-block-expanded-frame {
+          width: 100%;
+          height: 100%;
+          border: 1px solid var(--border);
+          border-radius: 8px;
         }
 
         .markdown-content .mermaid-block-loading {

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -442,15 +442,14 @@ export default function MarkdownRenderer({
           overflow: hidden;
         }
 
-        .markdown-content .render-viewer {
-          display: block;
+        .markdown-content .mermaid-block-content {
+          display: flex;
+          align-items: flex-start;
+          justify-content: center;
           width: 100%;
-          border: 0;
-          background-color: var(--background);
-        }
-
-        .markdown-content .mermaid-block-frame {
           min-height: min(70vh, 36rem);
+          padding: 1rem;
+          overflow: auto;
         }
 
         .markdown-content .mermaid-block-expand-button,
@@ -498,7 +497,10 @@ export default function MarkdownRenderer({
         .markdown-content .mermaid-block-expanded {
           position: fixed;
           inset: 0;
-          z-index: 80;
+          z-index: 1000;
+          box-sizing: border-box;
+          width: 100vw;
+          height: 100dvh;
           padding: 4.25rem 1rem 1rem;
           background-color: color-mix(in srgb, var(--background) 96%, black 4%);
         }
@@ -549,11 +551,28 @@ export default function MarkdownRenderer({
           right: 1rem;
         }
 
-        .markdown-content .mermaid-block-expanded-frame {
+        .markdown-content .mermaid-block-expanded-canvas {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          position: relative;
           width: 100%;
           height: 100%;
+          overflow: hidden;
+          cursor: grab;
+          user-select: none;
           border: 1px solid var(--border);
           border-radius: 8px;
+          background-color: var(--background);
+        }
+
+        .markdown-content .mermaid-block-expanded-canvas-dragging {
+          cursor: grabbing;
+        }
+
+        .markdown-content .mermaid-block-expanded-content {
+          flex: 0 0 auto;
+          padding: 2rem;
         }
 
         .markdown-content .mermaid-block-loading {

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -61,8 +61,10 @@ function createHeadingId(text: string, counts: Map<string, number>): string {
 
 const MERMAID_LANGUAGE_CLASS_PATTERN = /(?:^|\s)language-mermaid(?:\s|$)/;
 const BLOCKQUOTE_MARKER_ENTITY_SEQUENCE_PATTERN =
-  /^([ \t]*)((?:&(?:gt|#62|#x3e);[ \t]*)+)/gim;
+  /^( {0,3})((?:&(?:gt|#62|#x3e);[ \t]*)+)(.*)$/i;
 const BLOCKQUOTE_MARKER_ENTITY_PATTERN = /&(?:gt|#62|#x3e);/gi;
+const FENCED_CODE_BLOCK_PATTERN = /^ {0,3}(?:`{3,}|~{3,})/;
+const MARKDOWN_LINE_SEPARATOR_PATTERN = /(\r?\n)/;
 
 function findFirstReactElement(node: ReactNode): ReactElement | null {
   if (Array.isArray(node)) {
@@ -95,12 +97,43 @@ function extractTextFromReactNode(node: ReactNode): string {
   return "";
 }
 
+function restoreBlockquoteMarkerEntities(line: string): string {
+  const match = line.match(BLOCKQUOTE_MARKER_ENTITY_SEQUENCE_PATTERN);
+  if (!match) {
+    return line;
+  }
+
+  const [, indentation, markerSequence, rest] = match;
+  const hasMarkerSeparator = rest.length === 0 || /[ \t]$/.test(markerSequence);
+  if (!hasMarkerSeparator) {
+    return line;
+  }
+
+  return `${indentation}${markerSequence.replace(BLOCKQUOTE_MARKER_ENTITY_PATTERN, ">")}${rest}`;
+}
+
 function normalizeMarkdownSyntaxEntities(content: string): string {
-  return content.replace(
-    BLOCKQUOTE_MARKER_ENTITY_SEQUENCE_PATTERN,
-    (_match, indentation: string, markerSequence: string) =>
-      `${indentation}${markerSequence.replace(BLOCKQUOTE_MARKER_ENTITY_PATTERN, ">")}`,
-  );
+  let isInFencedCodeBlock = false;
+
+  return content
+    .split(MARKDOWN_LINE_SEPARATOR_PATTERN)
+    .map((line) => {
+      if (line === "\n" || line === "\r\n") {
+        return line;
+      }
+
+      if (FENCED_CODE_BLOCK_PATTERN.test(line)) {
+        isInFencedCodeBlock = !isInFencedCodeBlock;
+        return line;
+      }
+
+      if (isInFencedCodeBlock) {
+        return line;
+      }
+
+      return restoreBlockquoteMarkerEntities(line);
+    })
+    .join("");
 }
 
 export function extractTableOfContents(content: string): TableOfContentsHeading[] {
@@ -421,7 +454,8 @@ export default function MarkdownRenderer({
         }
 
         .markdown-content .mermaid-block-expand-button,
-        .markdown-content .mermaid-block-close-button {
+        .markdown-content .mermaid-block-close-button,
+        .markdown-content .mermaid-block-zoom-button {
           position: absolute;
           z-index: 1;
           display: inline-flex;
@@ -446,14 +480,17 @@ export default function MarkdownRenderer({
 
         .markdown-content .mermaid-block-expand-button:hover,
         .markdown-content .mermaid-block-close-button:hover,
+        .markdown-content .mermaid-block-zoom-button:hover,
         .markdown-content .mermaid-block-expand-button:focus-visible,
-        .markdown-content .mermaid-block-close-button:focus-visible {
+        .markdown-content .mermaid-block-close-button:focus-visible,
+        .markdown-content .mermaid-block-zoom-button:focus-visible {
           background-color: var(--muted);
           color: var(--foreground);
         }
 
         .markdown-content .mermaid-block-expand-button:focus-visible,
-        .markdown-content .mermaid-block-close-button:focus-visible {
+        .markdown-content .mermaid-block-close-button:focus-visible,
+        .markdown-content .mermaid-block-zoom-button:focus-visible {
           outline: 2px solid var(--color-blue-500);
           outline-offset: 2px;
         }
@@ -462,8 +499,49 @@ export default function MarkdownRenderer({
           position: fixed;
           inset: 0;
           z-index: 80;
-          padding: 3.5rem 1rem 1rem;
+          padding: 4.25rem 1rem 1rem;
           background-color: color-mix(in srgb, var(--background) 96%, black 4%);
+        }
+
+        .markdown-content .mermaid-block-expanded-toolbar {
+          position: absolute;
+          top: 1rem;
+          left: 1rem;
+          z-index: 1;
+          display: inline-flex;
+          align-items: center;
+          gap: 0.25rem;
+          padding: 0.25rem;
+          border: 1px solid var(--border);
+          border-radius: 8px;
+          background-color: color-mix(in srgb, var(--background) 94%, transparent);
+          box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
+        }
+
+        .markdown-content .mermaid-block-zoom-button {
+          position: static;
+          flex: 0 0 auto;
+          box-shadow: none;
+          background-color: transparent;
+        }
+
+        .markdown-content .mermaid-block-zoom-button:disabled {
+          cursor: not-allowed;
+          opacity: 0.45;
+        }
+
+        .markdown-content .mermaid-block-zoom-button:disabled:hover {
+          background-color: transparent;
+        }
+
+        .markdown-content .mermaid-block-zoom-value {
+          min-width: 3.25rem;
+          color: var(--foreground);
+          font-size: 0.75rem;
+          font-weight: 600;
+          font-variant-numeric: tabular-nums;
+          line-height: 2rem;
+          text-align: center;
         }
 
         .markdown-content .mermaid-block-close-button {

--- a/src/components/MermaidBlock.entities.test.mjs
+++ b/src/components/MermaidBlock.entities.test.mjs
@@ -31,21 +31,17 @@ test("mermaid block uses decoded code for rendering, error fallback, and loading
   assert.equal(decodedUsages.length, 2, "decodedCode should back both fallback panels");
 });
 
-test("mermaid block renders diagrams through sandboxed iframe viewers", () => {
-  assert.match(
-    mermaidBlockSource,
-    /function createMermaidViewerDocument\(\s*svg: string,\s*zoom = MERMAID_DIALOG_DEFAULT_ZOOM,\s*\): string/,
-  );
-  assert.match(mermaidBlockSource, /const viewerDocument = useMemo/);
-  assert.match(mermaidBlockSource, /const expandedViewerDocument = useMemo/);
-  assert.match(mermaidBlockSource, /className="render-viewer mermaid-block-frame"/);
-  assert.match(mermaidBlockSource, /className="render-viewer mermaid-block-expanded-frame"/);
-  assert.match(mermaidBlockSource, /sandbox=""/);
-  assert.doesNotMatch(mermaidBlockSource, /allow-same-origin/);
+test("mermaid block renders diagrams directly in normal and expanded views", () => {
+  assert.match(mermaidBlockSource, /if \(svg\) \{/);
+  assert.match(mermaidBlockSource, /className="mermaid-block-content"/);
+  assert.match(mermaidBlockSource, /className="mermaid-block-expanded-content"/);
+  const svgInsertions =
+    mermaidBlockSource.match(/dangerouslySetInnerHTML=\{\{ __html: svg \}\}/g) ?? [];
+  assert.equal(svgInsertions.length, 2, "normal and expanded views should render the SVG");
+  assert.doesNotMatch(mermaidBlockSource, /createMermaidViewerDocument/);
+  assert.doesNotMatch(mermaidBlockSource, /srcDoc=/);
+  assert.doesNotMatch(mermaidBlockSource, /sandbox=/);
   assert.doesNotMatch(mermaidBlockSource, /allow-scripts/);
-  assert.match(mermaidBlockSource, /srcDoc=\{viewerDocument\}/);
-  assert.match(mermaidBlockSource, /srcDoc=\{expandedViewerDocument\}/);
-  assert.doesNotMatch(mermaidBlockSource, /dangerouslySetInnerHTML=\{\{ __html: svg \}\}/);
 });
 
 test("mermaid block exposes an expanded viewer dialog", () => {
@@ -57,6 +53,7 @@ test("mermaid block exposes an expanded viewer dialog", () => {
   assert.match(mermaidBlockSource, /className="mermaid-block-expand-button"/);
   assert.match(mermaidBlockSource, /className="mermaid-block-expanded"/);
   assert.match(mermaidBlockSource, /className="mermaid-block-expanded-toolbar"/);
+  assert.match(mermaidBlockSource, /className=\{\[\s*"mermaid-block-expanded-canvas",/);
   assert.match(mermaidBlockSource, /aria-modal="true"/);
   assert.match(mermaidBlockSource, /tabIndex=\{-1\}/);
   assert.match(mermaidBlockSource, /role="toolbar"/);
@@ -74,17 +71,40 @@ test("expanded mermaid dialog traps focus and restores it on close", () => {
   assert.match(mermaidBlockSource, /previouslyFocusedElement\?\.focus\(\);/);
 });
 
-test("expanded mermaid dialog supports bounded zoom controls", () => {
-  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_DEFAULT_ZOOM = 1;/);
+test("expanded mermaid dialog supports fanplus-style pan and zoom controls", () => {
+  assert.match(mermaidBlockSource, /interface MermaidDialogPosition/);
+  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_DEFAULT_ZOOM = 3;/);
   assert.match(mermaidBlockSource, /const MERMAID_DIALOG_MIN_ZOOM = 0\.5;/);
-  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_MAX_ZOOM = 3;/);
-  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_ZOOM_STEP = 0\.25;/);
+  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_MAX_ZOOM = 20;/);
+  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_ZOOM_STEP = 0\.2;/);
+  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_WHEEL_ZOOM_STEP = 0\.1;/);
+  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_PAN_STEP = 50;/);
+  assert.match(
+    mermaidBlockSource,
+    /const \[expandedPosition, setExpandedPosition\] = useState<MermaidDialogPosition>/,
+  );
+  assert.match(mermaidBlockSource, /const \[isExpandedDragging, setIsExpandedDragging\] = useState\(false\);/);
   assert.match(mermaidBlockSource, /function clampMermaidDialogZoom\(zoom: number\): number/);
+  assert.match(mermaidBlockSource, /function getPannedMermaidDialogPosition/);
+  assert.match(mermaidBlockSource, /const startExpandedViewDrag =/);
+  assert.match(mermaidBlockSource, /const moveExpandedViewDrag =/);
+  assert.match(mermaidBlockSource, /const stopExpandedViewDrag =/);
+  assert.match(mermaidBlockSource, /container\.addEventListener\("wheel", handleWheel, \{ passive: false \}\);/);
+  assert.match(mermaidBlockSource, /case "ArrowUp":/);
+  assert.match(mermaidBlockSource, /case "ArrowDown":/);
+  assert.match(mermaidBlockSource, /case "ArrowLeft":/);
+  assert.match(mermaidBlockSource, /case "ArrowRight":/);
+  assert.match(mermaidBlockSource, /case "\+":/);
+  assert.match(mermaidBlockSource, /case "-":/);
+  assert.match(mermaidBlockSource, /case "0":/);
   assert.match(mermaidBlockSource, /aria-label="Mermaid diagram zoom out"/);
   assert.match(mermaidBlockSource, /aria-label="Mermaid diagram zoom in"/);
   assert.match(mermaidBlockSource, /aria-label="Mermaid diagram zoom reset"/);
-  assert.match(mermaidBlockSource, /zoom: \$\{safeZoom\};/);
-  assert.match(mermaidBlockSource, /transform: scale\(\$\{safeZoom\}\);/);
+  assert.match(
+    mermaidBlockSource,
+    /transform: `translate\(\$\{expandedPosition\.x\}px, \$\{expandedPosition\.y\}px\) scale\(\$\{expandedZoom\}\)`/,
+  );
+  assert.match(mermaidBlockSource, /transition: isExpandedDragging \? "none" : "transform 0\.1s ease-out"/);
 });
 
 test("decoder also supports numeric and hexadecimal html entities", () => {

--- a/src/components/MermaidBlock.entities.test.mjs
+++ b/src/components/MermaidBlock.entities.test.mjs
@@ -32,21 +32,59 @@ test("mermaid block uses decoded code for rendering, error fallback, and loading
 });
 
 test("mermaid block renders diagrams through sandboxed iframe viewers", () => {
-  assert.match(mermaidBlockSource, /function createMermaidViewerDocument\(svg: string\): string/);
+  assert.match(
+    mermaidBlockSource,
+    /function createMermaidViewerDocument\(\s*svg: string,\s*zoom = MERMAID_DIALOG_DEFAULT_ZOOM,\s*\): string/,
+  );
   assert.match(mermaidBlockSource, /const viewerDocument = useMemo/);
+  assert.match(mermaidBlockSource, /const expandedViewerDocument = useMemo/);
   assert.match(mermaidBlockSource, /className="render-viewer mermaid-block-frame"/);
   assert.match(mermaidBlockSource, /className="render-viewer mermaid-block-expanded-frame"/);
-  assert.match(mermaidBlockSource, /sandbox="allow-scripts allow-same-origin"/);
+  assert.match(mermaidBlockSource, /sandbox=""/);
+  assert.doesNotMatch(mermaidBlockSource, /allow-same-origin/);
+  assert.doesNotMatch(mermaidBlockSource, /allow-scripts/);
   assert.match(mermaidBlockSource, /srcDoc=\{viewerDocument\}/);
+  assert.match(mermaidBlockSource, /srcDoc=\{expandedViewerDocument\}/);
   assert.doesNotMatch(mermaidBlockSource, /dangerouslySetInnerHTML=\{\{ __html: svg \}\}/);
 });
 
 test("mermaid block exposes an expanded viewer dialog", () => {
   assert.match(mermaidBlockSource, /const \[isExpanded, setIsExpanded\] = useState\(false\);/);
+  assert.match(
+    mermaidBlockSource,
+    /const \[expandedZoom, setExpandedZoom\] = useState\(MERMAID_DIALOG_DEFAULT_ZOOM\);/,
+  );
   assert.match(mermaidBlockSource, /className="mermaid-block-expand-button"/);
   assert.match(mermaidBlockSource, /className="mermaid-block-expanded"/);
+  assert.match(mermaidBlockSource, /className="mermaid-block-expanded-toolbar"/);
   assert.match(mermaidBlockSource, /aria-modal="true"/);
+  assert.match(mermaidBlockSource, /tabIndex=\{-1\}/);
+  assert.match(mermaidBlockSource, /role="toolbar"/);
+  assert.match(mermaidBlockSource, /aria-label="Mermaid diagram zoom controls"/);
   assert.match(mermaidBlockSource, /event\.key === "Escape"/);
+});
+
+test("expanded mermaid dialog traps focus and restores it on close", () => {
+  assert.match(mermaidBlockSource, /const FOCUSABLE_DIALOG_ELEMENT_SELECTOR =/);
+  assert.match(mermaidBlockSource, /function getFocusableDialogElements\(container: HTMLElement\): HTMLElement\[\]/);
+  assert.match(mermaidBlockSource, /const expandedDialogRef = useRef<HTMLDivElement \| null>\(null\);/);
+  assert.match(mermaidBlockSource, /const previouslyFocusedElement =/);
+  assert.match(mermaidBlockSource, /event\.key !== "Tab"/);
+  assert.match(mermaidBlockSource, /event\.shiftKey/);
+  assert.match(mermaidBlockSource, /previouslyFocusedElement\?\.focus\(\);/);
+});
+
+test("expanded mermaid dialog supports bounded zoom controls", () => {
+  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_DEFAULT_ZOOM = 1;/);
+  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_MIN_ZOOM = 0\.5;/);
+  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_MAX_ZOOM = 3;/);
+  assert.match(mermaidBlockSource, /const MERMAID_DIALOG_ZOOM_STEP = 0\.25;/);
+  assert.match(mermaidBlockSource, /function clampMermaidDialogZoom\(zoom: number\): number/);
+  assert.match(mermaidBlockSource, /aria-label="Mermaid diagram zoom out"/);
+  assert.match(mermaidBlockSource, /aria-label="Mermaid diagram zoom in"/);
+  assert.match(mermaidBlockSource, /aria-label="Mermaid diagram zoom reset"/);
+  assert.match(mermaidBlockSource, /zoom: \$\{safeZoom\};/);
+  assert.match(mermaidBlockSource, /transform: scale\(\$\{safeZoom\}\);/);
 });
 
 test("decoder also supports numeric and hexadecimal html entities", () => {

--- a/src/components/MermaidBlock.entities.test.mjs
+++ b/src/components/MermaidBlock.entities.test.mjs
@@ -33,11 +33,26 @@ test("mermaid block uses decoded code for rendering, error fallback, and loading
 
 test("mermaid block renders diagrams directly in normal and expanded views", () => {
   assert.match(mermaidBlockSource, /if \(svg\) \{/);
+  assert.match(mermaidBlockSource, /function MermaidRenderedDiagram/);
+  assert.match(mermaidBlockSource, /role="img"/);
+  assert.match(mermaidBlockSource, /aria-label="Mermaid diagram"/);
   assert.match(mermaidBlockSource, /className="mermaid-block-content"/);
   assert.match(mermaidBlockSource, /className="mermaid-block-expanded-content"/);
   const svgInsertions =
     mermaidBlockSource.match(/dangerouslySetInnerHTML=\{\{ __html: svg \}\}/g) ?? [];
-  assert.equal(svgInsertions.length, 2, "normal and expanded views should render the SVG");
+  assert.equal(
+    svgInsertions.length,
+    1,
+    "normal and expanded views should share one accessible SVG insertion helper",
+  );
+  assert.match(
+    mermaidBlockSource,
+    /\{!isExpanded && \(\s*<MermaidRenderedDiagram className="mermaid-block-content" svg=\{svg\} \/>/,
+  );
+  assert.match(
+    mermaidBlockSource,
+    /<MermaidRenderedDiagram\s+className="mermaid-block-expanded-content"\s+svg=\{svg\}\s+style=\{expandedDiagramStyle\}/,
+  );
   assert.doesNotMatch(mermaidBlockSource, /createMermaidViewerDocument/);
   assert.doesNotMatch(mermaidBlockSource, /srcDoc=/);
   assert.doesNotMatch(mermaidBlockSource, /sandbox=/);

--- a/src/components/MermaidBlock.entities.test.mjs
+++ b/src/components/MermaidBlock.entities.test.mjs
@@ -31,6 +31,24 @@ test("mermaid block uses decoded code for rendering, error fallback, and loading
   assert.equal(decodedUsages.length, 2, "decodedCode should back both fallback panels");
 });
 
+test("mermaid block renders diagrams through sandboxed iframe viewers", () => {
+  assert.match(mermaidBlockSource, /function createMermaidViewerDocument\(svg: string\): string/);
+  assert.match(mermaidBlockSource, /const viewerDocument = useMemo/);
+  assert.match(mermaidBlockSource, /className="render-viewer mermaid-block-frame"/);
+  assert.match(mermaidBlockSource, /className="render-viewer mermaid-block-expanded-frame"/);
+  assert.match(mermaidBlockSource, /sandbox="allow-scripts allow-same-origin"/);
+  assert.match(mermaidBlockSource, /srcDoc=\{viewerDocument\}/);
+  assert.doesNotMatch(mermaidBlockSource, /dangerouslySetInnerHTML=\{\{ __html: svg \}\}/);
+});
+
+test("mermaid block exposes an expanded viewer dialog", () => {
+  assert.match(mermaidBlockSource, /const \[isExpanded, setIsExpanded\] = useState\(false\);/);
+  assert.match(mermaidBlockSource, /className="mermaid-block-expand-button"/);
+  assert.match(mermaidBlockSource, /className="mermaid-block-expanded"/);
+  assert.match(mermaidBlockSource, /aria-modal="true"/);
+  assert.match(mermaidBlockSource, /event\.key === "Escape"/);
+});
+
 test("decoder also supports numeric and hexadecimal html entities", () => {
   assert.match(
     mermaidBlockSource,

--- a/src/components/MermaidBlock.tsx
+++ b/src/components/MermaidBlock.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Maximize2, X } from "lucide-react";
+import { Maximize2, RotateCcw, X, ZoomIn, ZoomOut } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useTheme } from "./ThemeProvider";
 
@@ -18,6 +18,32 @@ const NAMED_HTML_ENTITY_MAP: Record<string, string> = {
 };
 
 const MAX_UNICODE_CODE_POINT = 0x10ffff;
+const MERMAID_DIALOG_DEFAULT_ZOOM = 1;
+const MERMAID_DIALOG_MIN_ZOOM = 0.5;
+const MERMAID_DIALOG_MAX_ZOOM = 3;
+const MERMAID_DIALOG_ZOOM_STEP = 0.25;
+const FOCUSABLE_DIALOG_ELEMENT_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "iframe",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(", ");
+
+function clampMermaidDialogZoom(zoom: number): number {
+  return Math.min(
+    MERMAID_DIALOG_MAX_ZOOM,
+    Math.max(MERMAID_DIALOG_MIN_ZOOM, zoom),
+  );
+}
+
+function getFocusableDialogElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_DIALOG_ELEMENT_SELECTOR),
+  );
+}
 
 function decodeCodePointEntity(codePoint: number, fallback: string): string {
   if (
@@ -56,7 +82,12 @@ function decodeMermaidEntities(input: string): string {
   );
 }
 
-function createMermaidViewerDocument(svg: string): string {
+function createMermaidViewerDocument(
+  svg: string,
+  zoom = MERMAID_DIALOG_DEFAULT_ZOOM,
+): string {
+  const safeZoom = clampMermaidDialogZoom(zoom);
+
   return `<!doctype html>
 <html>
   <head>
@@ -86,9 +117,21 @@ function createMermaidViewerDocument(svg: string): string {
         overflow: auto;
       }
 
-      svg {
+      .mermaid-viewer-content {
         display: block;
         flex: 0 0 auto;
+        zoom: ${safeZoom};
+      }
+
+      @supports not (zoom: 1) {
+        .mermaid-viewer-content {
+          transform: scale(${safeZoom});
+          transform-origin: top center;
+        }
+      }
+
+      svg {
+        display: block;
         width: auto;
         max-width: none;
         height: auto;
@@ -96,7 +139,7 @@ function createMermaidViewerDocument(svg: string): string {
     </style>
   </head>
   <body>
-    ${svg}
+    <div class="mermaid-viewer-content">${svg}</div>
   </body>
 </html>`;
 }
@@ -117,12 +160,46 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
   const [svg, setSvg] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [expandedZoom, setExpandedZoom] = useState(MERMAID_DIALOG_DEFAULT_ZOOM);
+  const expandedDialogRef = useRef<HTMLDivElement | null>(null);
   const renderTokenRef = useRef(0);
   const decodedCode = useMemo(() => decodeMermaidEntities(code), [code]);
   const viewerDocument = useMemo(
     () => (svg ? createMermaidViewerDocument(svg) : null),
     [svg],
   );
+  const expandedViewerDocument = useMemo(
+    () => (svg ? createMermaidViewerDocument(svg, expandedZoom) : null),
+    [expandedZoom, svg],
+  );
+  const expandedZoomPercent = Math.round(expandedZoom * 100);
+  const canZoomOut = expandedZoom > MERMAID_DIALOG_MIN_ZOOM;
+  const canZoomIn = expandedZoom < MERMAID_DIALOG_MAX_ZOOM;
+
+  const openExpandedView = () => {
+    setExpandedZoom(MERMAID_DIALOG_DEFAULT_ZOOM);
+    setIsExpanded(true);
+  };
+
+  const closeExpandedView = () => {
+    setIsExpanded(false);
+  };
+
+  const zoomOutExpandedView = () => {
+    setExpandedZoom((currentZoom) =>
+      clampMermaidDialogZoom(currentZoom - MERMAID_DIALOG_ZOOM_STEP),
+    );
+  };
+
+  const zoomInExpandedView = () => {
+    setExpandedZoom((currentZoom) =>
+      clampMermaidDialogZoom(currentZoom + MERMAID_DIALOG_ZOOM_STEP),
+    );
+  };
+
+  const resetExpandedViewZoom = () => {
+    setExpandedZoom(MERMAID_DIALOG_DEFAULT_ZOOM);
+  };
 
   useEffect(() => {
     const trimmedCode = decodedCode.trim();
@@ -180,14 +257,68 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
       return;
     }
 
+    const previouslyFocusedElement =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const focusFrame = window.requestAnimationFrame(() => {
+      const dialogElement = expandedDialogRef.current;
+      if (!dialogElement) {
+        return;
+      }
+
+      const firstFocusableElement = getFocusableDialogElements(dialogElement)[0];
+      (firstFocusableElement ?? dialogElement).focus();
+    });
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setIsExpanded(false);
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const dialogElement = expandedDialogRef.current;
+      if (!dialogElement) {
+        return;
+      }
+
+      const focusableElements = getFocusableDialogElements(dialogElement);
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        dialogElement.focus();
+        return;
+      }
+
+      const firstFocusableElement = focusableElements[0];
+      const lastFocusableElement = focusableElements[focusableElements.length - 1];
+      const activeElement = document.activeElement;
+
+      if (
+        event.shiftKey &&
+        (activeElement === firstFocusableElement ||
+          !dialogElement.contains(activeElement))
+      ) {
+        event.preventDefault();
+        lastFocusableElement.focus();
+        return;
+      }
+
+      if (!event.shiftKey && activeElement === lastFocusableElement) {
+        event.preventDefault();
+        firstFocusableElement.focus();
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    return () => {
+      window.cancelAnimationFrame(focusFrame);
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocusedElement?.focus();
+    };
   }, [isExpanded]);
 
   useEffect(() => {
@@ -216,7 +347,7 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
             type="button"
             className="mermaid-block-expand-button"
             aria-label="Mermaid diagram expand"
-            onClick={() => setIsExpanded(true)}
+            onClick={openExpandedView}
           >
             <Maximize2 aria-hidden="true" size={16} />
           </button>
@@ -224,23 +355,60 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
             title="Mermaid diagram"
             role="presentation"
             className="render-viewer mermaid-block-frame"
-            sandbox="allow-scripts allow-same-origin"
+            sandbox=""
             srcDoc={viewerDocument}
           />
         </div>
 
-        {isExpanded && (
+        {isExpanded && expandedViewerDocument && (
           <div
+            ref={expandedDialogRef}
             className="mermaid-block-expanded"
             role="dialog"
             aria-modal="true"
             aria-label="Mermaid diagram expanded view"
+            tabIndex={-1}
           >
+            <div
+              className="mermaid-block-expanded-toolbar"
+              role="toolbar"
+              aria-label="Mermaid diagram zoom controls"
+            >
+              <button
+                type="button"
+                className="mermaid-block-zoom-button"
+                aria-label="Mermaid diagram zoom out"
+                disabled={!canZoomOut}
+                onClick={zoomOutExpandedView}
+              >
+                <ZoomOut aria-hidden="true" size={18} />
+              </button>
+              <span className="mermaid-block-zoom-value" aria-live="polite">
+                {expandedZoomPercent}%
+              </span>
+              <button
+                type="button"
+                className="mermaid-block-zoom-button"
+                aria-label="Mermaid diagram zoom in"
+                disabled={!canZoomIn}
+                onClick={zoomInExpandedView}
+              >
+                <ZoomIn aria-hidden="true" size={18} />
+              </button>
+              <button
+                type="button"
+                className="mermaid-block-zoom-button"
+                aria-label="Mermaid diagram zoom reset"
+                onClick={resetExpandedViewZoom}
+              >
+                <RotateCcw aria-hidden="true" size={18} />
+              </button>
+            </div>
             <button
               type="button"
               className="mermaid-block-close-button"
               aria-label="Mermaid diagram close"
-              onClick={() => setIsExpanded(false)}
+              onClick={closeExpandedView}
             >
               <X aria-hidden="true" size={18} />
             </button>
@@ -248,8 +416,8 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
               title="Mermaid diagram expanded"
               role="presentation"
               className="render-viewer mermaid-block-expanded-frame"
-              sandbox="allow-scripts allow-same-origin"
-              srcDoc={viewerDocument}
+              sandbox=""
+              srcDoc={expandedViewerDocument}
             />
           </div>
         )}

--- a/src/components/MermaidBlock.tsx
+++ b/src/components/MermaidBlock.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Maximize2, X } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useTheme } from "./ThemeProvider";
 
@@ -55,6 +56,51 @@ function decodeMermaidEntities(input: string): string {
   );
 }
 
+function createMermaidViewerDocument(svg: string): string {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: var(--font-app-mono, ui-monospace), SFMono-Regular, Menlo, monospace;
+      }
+
+      html,
+      body {
+        min-width: 100%;
+        min-height: 100%;
+        margin: 0;
+        background: transparent;
+      }
+
+      body {
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        box-sizing: border-box;
+        width: max-content;
+        padding: 16px;
+        overflow: auto;
+      }
+
+      svg {
+        display: block;
+        flex: 0 0 auto;
+        width: auto;
+        max-width: none;
+        height: auto;
+      }
+    </style>
+  </head>
+  <body>
+    ${svg}
+  </body>
+</html>`;
+}
+
 /**
  * mermaid 코드 블록을 SVG 다이어그램으로 렌더링한다.
  * mermaid 모듈은 window 의존성이 있어 클라이언트에서만 동적으로 로드한다.
@@ -70,8 +116,13 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
   const isDarkTheme = resolvedTheme === "dark";
   const [svg, setSvg] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
   const renderTokenRef = useRef(0);
   const decodedCode = useMemo(() => decodeMermaidEntities(code), [code]);
+  const viewerDocument = useMemo(
+    () => (svg ? createMermaidViewerDocument(svg) : null),
+    [svg],
+  );
 
   useEffect(() => {
     const trimmedCode = decodedCode.trim();
@@ -124,6 +175,27 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
     };
   }, [decodedCode, isDarkTheme, sanitizedId]);
 
+  useEffect(() => {
+    if (!isExpanded) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsExpanded(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isExpanded]);
+
+  useEffect(() => {
+    if (!svg) {
+      setIsExpanded(false);
+    }
+  }, [svg]);
+
   if (errorMessage) {
     return (
       <div className="mermaid-block mermaid-block-error" role="alert">
@@ -136,14 +208,52 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
     );
   }
 
-  if (svg) {
+  if (viewerDocument) {
     return (
-      <div
-        className="mermaid-block"
-        role="img"
-        aria-label="Mermaid diagram"
-        dangerouslySetInnerHTML={{ __html: svg }}
-      />
+      <>
+        <div className="mermaid-block mermaid-block-viewer">
+          <button
+            type="button"
+            className="mermaid-block-expand-button"
+            aria-label="Mermaid diagram expand"
+            onClick={() => setIsExpanded(true)}
+          >
+            <Maximize2 aria-hidden="true" size={16} />
+          </button>
+          <iframe
+            title="Mermaid diagram"
+            role="presentation"
+            className="render-viewer mermaid-block-frame"
+            sandbox="allow-scripts allow-same-origin"
+            srcDoc={viewerDocument}
+          />
+        </div>
+
+        {isExpanded && (
+          <div
+            className="mermaid-block-expanded"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Mermaid diagram expanded view"
+          >
+            <button
+              type="button"
+              className="mermaid-block-close-button"
+              aria-label="Mermaid diagram close"
+              onClick={() => setIsExpanded(false)}
+            >
+              <X aria-hidden="true" size={18} />
+            </button>
+            <iframe
+              title="Mermaid diagram expanded"
+              role="presentation"
+              className="render-viewer mermaid-block-expanded-frame"
+              sandbox="allow-scripts allow-same-origin"
+              srcDoc={viewerDocument}
+            />
+          </div>
+        )}
+      </>
     );
   }
 
@@ -156,4 +266,4 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
   );
 }
 
-export { decodeMermaidEntities };
+export { createMermaidViewerDocument, decodeMermaidEntities };

--- a/src/components/MermaidBlock.tsx
+++ b/src/components/MermaidBlock.tsx
@@ -2,6 +2,7 @@
 
 import { Maximize2, RotateCcw, X, ZoomIn, ZoomOut } from "lucide-react";
 import {
+  type CSSProperties,
   type MouseEvent,
   useCallback,
   useEffect,
@@ -19,6 +20,12 @@ interface MermaidBlockProps {
 interface MermaidDialogPosition {
   x: number;
   y: number;
+}
+
+interface MermaidRenderedDiagramProps {
+  className: string;
+  svg: string;
+  style?: CSSProperties;
 }
 
 const NAMED_HTML_ENTITY_MAP: Record<string, string> = {
@@ -110,6 +117,22 @@ function decodeMermaidEntities(input: string): string {
 
       return NAMED_HTML_ENTITY_MAP[match] ?? match;
     },
+  );
+}
+
+function MermaidRenderedDiagram({
+  className,
+  svg,
+  style,
+}: MermaidRenderedDiagramProps) {
+  return (
+    <div
+      className={className}
+      role="img"
+      aria-label="Mermaid diagram"
+      style={style}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
   );
 }
 
@@ -430,10 +453,9 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
           >
             <Maximize2 aria-hidden="true" size={16} />
           </button>
-          <div
-            className="mermaid-block-content"
-            dangerouslySetInnerHTML={{ __html: svg }}
-          />
+          {!isExpanded && (
+            <MermaidRenderedDiagram className="mermaid-block-content" svg={svg} />
+          )}
         </div>
 
         {isExpanded && (
@@ -501,10 +523,10 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
               onMouseUp={stopExpandedViewDrag}
               onMouseLeave={stopExpandedViewDrag}
             >
-              <div
+              <MermaidRenderedDiagram
                 className="mermaid-block-expanded-content"
+                svg={svg}
                 style={expandedDiagramStyle}
-                dangerouslySetInnerHTML={{ __html: svg }}
               />
             </div>
           </div>

--- a/src/components/MermaidBlock.tsx
+++ b/src/components/MermaidBlock.tsx
@@ -1,11 +1,24 @@
 "use client";
 
 import { Maximize2, RotateCcw, X, ZoomIn, ZoomOut } from "lucide-react";
-import { useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTheme } from "./ThemeProvider";
 
 interface MermaidBlockProps {
   code: string;
+}
+
+interface MermaidDialogPosition {
+  x: number;
+  y: number;
 }
 
 const NAMED_HTML_ENTITY_MAP: Record<string, string> = {
@@ -18,14 +31,16 @@ const NAMED_HTML_ENTITY_MAP: Record<string, string> = {
 };
 
 const MAX_UNICODE_CODE_POINT = 0x10ffff;
-const MERMAID_DIALOG_DEFAULT_ZOOM = 1;
+const MERMAID_DIALOG_DEFAULT_ZOOM = 3;
 const MERMAID_DIALOG_MIN_ZOOM = 0.5;
-const MERMAID_DIALOG_MAX_ZOOM = 3;
-const MERMAID_DIALOG_ZOOM_STEP = 0.25;
+const MERMAID_DIALOG_MAX_ZOOM = 20;
+const MERMAID_DIALOG_ZOOM_STEP = 0.2;
+const MERMAID_DIALOG_WHEEL_ZOOM_STEP = 0.1;
+const MERMAID_DIALOG_PAN_STEP = 50;
+const MERMAID_DIALOG_DEFAULT_POSITION: MermaidDialogPosition = { x: 0, y: 0 };
 const FOCUSABLE_DIALOG_ELEMENT_SELECTOR = [
   "a[href]",
   "button:not([disabled])",
-  "iframe",
   "input:not([disabled])",
   "select:not([disabled])",
   "textarea:not([disabled])",
@@ -37,6 +52,22 @@ function clampMermaidDialogZoom(zoom: number): number {
     MERMAID_DIALOG_MAX_ZOOM,
     Math.max(MERMAID_DIALOG_MIN_ZOOM, zoom),
   );
+}
+
+function getPannedMermaidDialogPosition(
+  position: MermaidDialogPosition,
+  direction: "up" | "down" | "left" | "right",
+): MermaidDialogPosition {
+  switch (direction) {
+    case "up":
+      return { ...position, y: position.y + MERMAID_DIALOG_PAN_STEP };
+    case "down":
+      return { ...position, y: position.y - MERMAID_DIALOG_PAN_STEP };
+    case "left":
+      return { ...position, x: position.x + MERMAID_DIALOG_PAN_STEP };
+    case "right":
+      return { ...position, x: position.x - MERMAID_DIALOG_PAN_STEP };
+  }
 }
 
 function getFocusableDialogElements(container: HTMLElement): HTMLElement[] {
@@ -82,68 +113,6 @@ function decodeMermaidEntities(input: string): string {
   );
 }
 
-function createMermaidViewerDocument(
-  svg: string,
-  zoom = MERMAID_DIALOG_DEFAULT_ZOOM,
-): string {
-  const safeZoom = clampMermaidDialogZoom(zoom);
-
-  return `<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <style>
-      :root {
-        color-scheme: light dark;
-        font-family: var(--font-app-mono, ui-monospace), SFMono-Regular, Menlo, monospace;
-      }
-
-      html,
-      body {
-        min-width: 100%;
-        min-height: 100%;
-        margin: 0;
-        background: transparent;
-      }
-
-      body {
-        display: flex;
-        align-items: flex-start;
-        justify-content: center;
-        box-sizing: border-box;
-        width: max-content;
-        padding: 16px;
-        overflow: auto;
-      }
-
-      .mermaid-viewer-content {
-        display: block;
-        flex: 0 0 auto;
-        zoom: ${safeZoom};
-      }
-
-      @supports not (zoom: 1) {
-        .mermaid-viewer-content {
-          transform: scale(${safeZoom});
-          transform-origin: top center;
-        }
-      }
-
-      svg {
-        display: block;
-        width: auto;
-        max-width: none;
-        height: auto;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="mermaid-viewer-content">${svg}</div>
-  </body>
-</html>`;
-}
-
 /**
  * mermaid 코드 블록을 SVG 다이어그램으로 렌더링한다.
  * mermaid 모듈은 window 의존성이 있어 클라이언트에서만 동적으로 로드한다.
@@ -161,23 +130,34 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const [expandedZoom, setExpandedZoom] = useState(MERMAID_DIALOG_DEFAULT_ZOOM);
+  const [expandedPosition, setExpandedPosition] = useState<MermaidDialogPosition>(
+    MERMAID_DIALOG_DEFAULT_POSITION,
+  );
+  const [isExpandedDragging, setIsExpandedDragging] = useState(false);
+  const [expandedDragStart, setExpandedDragStart] = useState<MermaidDialogPosition>(
+    MERMAID_DIALOG_DEFAULT_POSITION,
+  );
   const expandedDialogRef = useRef<HTMLDivElement | null>(null);
+  const expandedViewerContainerRef = useRef<HTMLDivElement | null>(null);
   const renderTokenRef = useRef(0);
   const decodedCode = useMemo(() => decodeMermaidEntities(code), [code]);
-  const viewerDocument = useMemo(
-    () => (svg ? createMermaidViewerDocument(svg) : null),
-    [svg],
-  );
-  const expandedViewerDocument = useMemo(
-    () => (svg ? createMermaidViewerDocument(svg, expandedZoom) : null),
-    [expandedZoom, svg],
-  );
   const expandedZoomPercent = Math.round(expandedZoom * 100);
   const canZoomOut = expandedZoom > MERMAID_DIALOG_MIN_ZOOM;
   const canZoomIn = expandedZoom < MERMAID_DIALOG_MAX_ZOOM;
+  const expandedDiagramStyle = {
+    transform: `translate(${expandedPosition.x}px, ${expandedPosition.y}px) scale(${expandedZoom})`,
+    transformOrigin: "center",
+    transition: isExpandedDragging ? "none" : "transform 0.1s ease-out",
+  };
+
+  const resetExpandedView = useCallback(() => {
+    setExpandedZoom(MERMAID_DIALOG_DEFAULT_ZOOM);
+    setExpandedPosition(MERMAID_DIALOG_DEFAULT_POSITION);
+    setIsExpandedDragging(false);
+  }, []);
 
   const openExpandedView = () => {
-    setExpandedZoom(MERMAID_DIALOG_DEFAULT_ZOOM);
+    resetExpandedView();
     setIsExpanded(true);
   };
 
@@ -198,7 +178,35 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
   };
 
   const resetExpandedViewZoom = () => {
-    setExpandedZoom(MERMAID_DIALOG_DEFAULT_ZOOM);
+    resetExpandedView();
+  };
+
+  const startExpandedViewDrag = (event: MouseEvent<HTMLDivElement>) => {
+    if (!isExpanded || event.button !== 0) {
+      return;
+    }
+
+    event.preventDefault();
+    setIsExpandedDragging(true);
+    setExpandedDragStart({
+      x: event.clientX - expandedPosition.x,
+      y: event.clientY - expandedPosition.y,
+    });
+  };
+
+  const moveExpandedViewDrag = (event: MouseEvent<HTMLDivElement>) => {
+    if (!isExpanded || !isExpandedDragging) {
+      return;
+    }
+
+    setExpandedPosition({
+      x: event.clientX - expandedDragStart.x,
+      y: event.clientY - expandedDragStart.y,
+    });
+  };
+
+  const stopExpandedViewDrag = () => {
+    setIsExpandedDragging(false);
   };
 
   useEffect(() => {
@@ -257,6 +265,14 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
       return;
     }
 
+    resetExpandedView();
+  }, [isExpanded, resetExpandedView]);
+
+  useEffect(() => {
+    if (!isExpanded) {
+      return;
+    }
+
     const previouslyFocusedElement =
       document.activeElement instanceof HTMLElement
         ? document.activeElement
@@ -275,6 +291,50 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
       if (event.key === "Escape") {
         setIsExpanded(false);
         return;
+      }
+
+      switch (event.key) {
+        case "ArrowUp":
+          event.preventDefault();
+          setExpandedPosition((position) =>
+            getPannedMermaidDialogPosition(position, "up"),
+          );
+          return;
+        case "ArrowDown":
+          event.preventDefault();
+          setExpandedPosition((position) =>
+            getPannedMermaidDialogPosition(position, "down"),
+          );
+          return;
+        case "ArrowLeft":
+          event.preventDefault();
+          setExpandedPosition((position) =>
+            getPannedMermaidDialogPosition(position, "left"),
+          );
+          return;
+        case "ArrowRight":
+          event.preventDefault();
+          setExpandedPosition((position) =>
+            getPannedMermaidDialogPosition(position, "right"),
+          );
+          return;
+        case "+":
+        case "=":
+          event.preventDefault();
+          setExpandedZoom((zoom) =>
+            clampMermaidDialogZoom(zoom + MERMAID_DIALOG_ZOOM_STEP),
+          );
+          return;
+        case "-":
+          event.preventDefault();
+          setExpandedZoom((zoom) =>
+            clampMermaidDialogZoom(zoom - MERMAID_DIALOG_ZOOM_STEP),
+          );
+          return;
+        case "0":
+          event.preventDefault();
+          resetExpandedView();
+          return;
       }
 
       if (event.key !== "Tab") {
@@ -319,6 +379,25 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
       document.removeEventListener("keydown", handleKeyDown);
       previouslyFocusedElement?.focus();
     };
+  }, [isExpanded, resetExpandedView]);
+
+  useEffect(() => {
+    const container = expandedViewerContainerRef.current;
+    if (!isExpanded || !container) {
+      return;
+    }
+
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const zoomDelta =
+        event.deltaY > 0
+          ? -MERMAID_DIALOG_WHEEL_ZOOM_STEP
+          : MERMAID_DIALOG_WHEEL_ZOOM_STEP;
+      setExpandedZoom((zoom) => clampMermaidDialogZoom(zoom + zoomDelta));
+    };
+
+    container.addEventListener("wheel", handleWheel, { passive: false });
+    return () => container.removeEventListener("wheel", handleWheel);
   }, [isExpanded]);
 
   useEffect(() => {
@@ -339,7 +418,7 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
     );
   }
 
-  if (viewerDocument) {
+  if (svg) {
     return (
       <>
         <div className="mermaid-block mermaid-block-viewer">
@@ -351,16 +430,13 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
           >
             <Maximize2 aria-hidden="true" size={16} />
           </button>
-          <iframe
-            title="Mermaid diagram"
-            role="presentation"
-            className="render-viewer mermaid-block-frame"
-            sandbox=""
-            srcDoc={viewerDocument}
+          <div
+            className="mermaid-block-content"
+            dangerouslySetInnerHTML={{ __html: svg }}
           />
         </div>
 
-        {isExpanded && expandedViewerDocument && (
+        {isExpanded && (
           <div
             ref={expandedDialogRef}
             className="mermaid-block-expanded"
@@ -412,13 +488,25 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
             >
               <X aria-hidden="true" size={18} />
             </button>
-            <iframe
-              title="Mermaid diagram expanded"
-              role="presentation"
-              className="render-viewer mermaid-block-expanded-frame"
-              sandbox=""
-              srcDoc={expandedViewerDocument}
-            />
+            <div
+              ref={expandedViewerContainerRef}
+              className={[
+                "mermaid-block-expanded-canvas",
+                isExpandedDragging ? "mermaid-block-expanded-canvas-dragging" : "",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+              onMouseDown={startExpandedViewDrag}
+              onMouseMove={moveExpandedViewDrag}
+              onMouseUp={stopExpandedViewDrag}
+              onMouseLeave={stopExpandedViewDrag}
+            >
+              <div
+                className="mermaid-block-expanded-content"
+                style={expandedDiagramStyle}
+                dangerouslySetInnerHTML={{ __html: svg }}
+              />
+            </div>
           </div>
         )}
       </>
@@ -434,4 +522,4 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
   );
 }
 
-export { createMermaidViewerDocument, decodeMermaidEntities };
+export { decodeMermaidEntities };


### PR DESCRIPTION
## 어떤 작업인가요?
- 상세 페이지 Markdown의 Mermaid 다이어그램을 직접 렌더링하고, 전체화면 dialog 안에서 확대/축소 및 패닝할 수 있도록 개선했습니다.
- HTML entity로 저장된 실제 인용문 marker만 안전하게 복원하도록 Markdown 정규화 범위도 제한했습니다.

<img width="1624" height="1061" alt="mermaid-detail" src="https://github.com/user-attachments/assets/54d4e6a6-74b1-475d-ad66-a8d0fcff9750" />
<img width="621" height="540" alt="mermaid" src="https://github.com/user-attachments/assets/b130e6fa-76d7-4443-b51d-71f73fe51dcc" />



## 어떻게 해결했나요?
**Mermaid 렌더링과 확장 뷰어 개선**
- iframe `srcDoc` 뷰어를 제거하고 Mermaid SVG를 일반 뷰와 확장 뷰에 직접 렌더링해 빈 화면 문제를 해결했습니다.
- 확장 버튼 클릭 시 viewport 전체 크기의 dialog를 열고, dialog 내부 canvas에서 드래그 패닝과 휠 확대/축소를 지원했습니다.
- 버튼, `+`/`-`/`0`, 방향키로 확대/축소/초기화/패닝할 수 있게 했습니다.
- 기본 확대율을 300%, 최대 확대 제한을 2000%로 설정했습니다.
- modal dialog focus trap과 닫힘 후 focus 복원을 유지했습니다.

**Mermaid 접근성과 DOM 안정성 보강**
- Mermaid SVG 삽입 컨테이너에 `role="img"`와 `aria-label="Mermaid diagram"`을 적용해 접근 가능한 이름을 복원했습니다.
- 확장 dialog가 열린 동안 기본 뷰 SVG를 unmount해 동일 Mermaid SVG 내부 id가 DOM에 중복되지 않도록 했습니다.
- normal/expanded 뷰가 같은 접근성 semantics를 쓰도록 공통 렌더링 헬퍼로 정리했습니다.

**인용문 엔티티 복원 안정화**
- 마크다운 파싱 전에 줄 시작의 `&gt;`, `&#62;`, `&#x3e;` blockquote marker를 `>`로 복원했습니다.
- fenced code block 내부와 marker 뒤 구분자가 없는 리터럴 entity는 복원 대상에서 제외했습니다.
- 중첩 인용문 marker도 실제 인용문 후보일 때만 연속 복원되도록 제한했습니다.

**스타일과 검증 코드 보강**
- Mermaid 일반 뷰, 전체화면 dialog, canvas, zoom toolbar 스타일을 직접 렌더링 구조에 맞게 갱신했습니다.
- iframe/sandbox 기반 검증을 제거하고 직접 SVG 렌더링, 전체화면 dialog, pan/zoom, focus 관리 검증을 반영했습니다.
- 접근성 semantics와 확장 뷰 open 시 중복 SVG 삽입 방지 조건을 테스트에 반영했습니다.
- blockquote marker 복원 제한과 Mermaid 뷰어 스타일 검증을 갱신했습니다.

## 중요한 변경 사항은 무엇인가요?
### Mermaid 확장 뷰어

**SVG 직접 렌더링 전환**
- **변경 이유**: sandboxed iframe `srcDoc` 구조에서 다이어그램이 비어 보이는 문제를 제거하고, 일반 뷰와 확장 뷰가 같은 SVG 결과를 안정적으로 표시하게 하기 위해서입니다.
- **수정 파일**: `src/components/MermaidBlock.tsx`, `src/components/MarkdownRenderer.tsx`

**전체화면 dialog와 내부 pan/zoom 추가**
- **변경 이유**: 큰 Mermaid 다이어그램을 dialog 안에서 직접 확대, 축소, 이동하며 확인할 수 있게 하기 위해서입니다.
- **수정 파일**: `src/components/MermaidBlock.tsx`, `src/components/MarkdownRenderer.tsx`

**접근성 semantics 복원**
- **변경 이유**: 직접 SVG 삽입 구조에서도 스크린 리더가 Mermaid 다이어그램을 안정적인 이름을 가진 이미지로 인식하게 하기 위해서입니다.
- **수정 파일**: `src/components/MermaidBlock.tsx`

**중복 SVG id 방지**
- **변경 이유**: 확장 dialog가 열렸을 때 동일 Mermaid SVG가 normal/expanded 뷰에 동시에 존재해 내부 `id`와 `url(#...)` 참조가 충돌하는 문제를 막기 위해서입니다.
- **수정 파일**: `src/components/MermaidBlock.tsx`

**기본/최대 확대 배율 조정**
- **변경 이유**: 확장 뷰 진입 직후 더 크게 보이게 하고, 복잡한 다이어그램도 충분히 확대할 수 있게 하기 위해서입니다.
- **수정 파일**: `src/components/MermaidBlock.tsx`

### Quote marker 복원

**마크다운 파싱 전 blockquote marker 정규화 제한**
- **변경 이유**: 서버에서 실제 인용문 marker가 HTML entity로 전달되는 경우만 복원하고, fenced code block 또는 리터럴 entity 예시가 blockquote로 바뀌는 데이터 손실을 막기 위해서입니다.
- **수정 파일**: `src/components/MarkdownRenderer.tsx`

### 검증 코드

**Mermaid와 blockquote 검증 갱신**
- **변경 이유**: 직접 렌더링 구조, 전체화면 dialog 스타일, pan/zoom 동작, 접근성 semantics, blockquote entity 복원 제한을 회귀 방지 대상으로 고정하기 위해서입니다.
- **수정 파일**: `src/components/MermaidBlock.entities.test.mjs`, `src/components/MarkdownRenderer.styles.test.mjs`

Co-Authored-By: OpenAI Codex <codex@openai.com>
