### PR TITLE
feat(links): 링크 목록 v1 API와 통계 표시 연동

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -77,7 +77,8 @@
       "latest": "Latest",
       "comments": "Comments",
       "views": "Views",
-      "likes": "Likes"
+      "likes": "Likes",
+      "saves": "Saves"
     }
   },
   "PostList": {
@@ -95,7 +96,10 @@
     "source": "Source",
     "publishedAt": "Published",
     "read": "Read",
-    "unread": "Unread"
+    "unread": "Unread",
+    "views": "Views",
+    "likes": "Likes",
+    "saves": "Saves"
   },
   "LinksPage": {
     "title": "Links",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -77,7 +77,8 @@
       "latest": "新着順",
       "comments": "コメント順",
       "views": "閲覧順",
-      "likes": "いいね順"
+      "likes": "いいね順",
+      "saves": "保存順"
     }
   },
   "PostList": {
@@ -95,7 +96,10 @@
     "source": "出典",
     "publishedAt": "公開日",
     "read": "既読",
-    "unread": "未読"
+    "unread": "未読",
+    "views": "閲覧数",
+    "likes": "いいね",
+    "saves": "保存"
   },
   "LinksPage": {
     "title": "リンク",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -77,7 +77,8 @@
       "latest": "최신순",
       "comments": "댓글순",
       "views": "조회순",
-      "likes": "추천순"
+      "likes": "추천순",
+      "saves": "저장순"
     }
   },
   "PostList": {
@@ -95,7 +96,10 @@
     "source": "출처",
     "publishedAt": "발행일",
     "read": "읽음",
-    "unread": "읽지않음"
+    "unread": "읽지않음",
+    "views": "조회수",
+    "likes": "좋아요",
+    "saves": "저장"
   },
   "LinksPage": {
     "title": "링크",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -77,7 +77,8 @@
       "latest": "最新",
       "comments": "评论",
       "views": "浏览",
-      "likes": "点赞"
+      "likes": "点赞",
+      "saves": "保存"
     }
   },
   "PostList": {
@@ -95,7 +96,10 @@
     "source": "来源",
     "publishedAt": "发布时间",
     "read": "已读",
-    "unread": "未读"
+    "unread": "未读",
+    "views": "浏览",
+    "likes": "点赞",
+    "saves": "保存"
   },
   "LinksPage": {
     "title": "链接",

--- a/src/components/links/LinkCard.tsx
+++ b/src/components/links/LinkCard.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { CalendarDays, Check, Circle } from "lucide-react";
+import { Bookmark, CalendarDays, Check, Circle, Eye, ThumbsUp } from "lucide-react";
 import { Link } from "../../i18n/navigation";
 import { getSafeExternalUrl } from "../../lib/safeExternalUrl";
 import { createLinkViewLog } from "../../services/links/client";
 import type { LinkContent } from "../../services/links/types";
 import { formatDisplayTime } from "../../utils";
+
+export interface LinkCountLabels {
+  views: string;
+  likes: string;
+  saves: string;
+}
 
 interface LinkCardProps {
   link: LinkContent;
@@ -14,6 +20,7 @@ interface LinkCardProps {
   readStatus?: boolean;
   readLabel: string;
   unreadLabel: string;
+  countLabels: LinkCountLabels;
 }
 
 function buildTagPath(tagName: string): string {
@@ -32,6 +39,10 @@ function resolveDisplayTime(link: LinkContent): string {
   return link.publishedAt || link.createdAt || link.updatedAt || "";
 }
 
+function formatCount(value: number | undefined, locale: string): string {
+  return new Intl.NumberFormat(locale).format(value ?? 0);
+}
+
 export default function LinkCard({
   link,
   locale,
@@ -39,12 +50,18 @@ export default function LinkCard({
   readStatus,
   readLabel,
   unreadLabel,
+  countLabels,
 }: LinkCardProps) {
   const previewTags = link.tags.slice(0, 3);
   const hiddenTagCount = Math.max(link.tags.length - previewTags.length, 0);
   const displayTime = resolveDisplayTime(link);
   const detailPath = `/links/${encodeURIComponent(link.id)}`;
   const sourceUrl = getSafeExternalUrl(link.url);
+  const countItems = [
+    { key: "views", label: countLabels.views, value: link.viewCount, icon: Eye },
+    { key: "likes", label: countLabels.likes, value: link.likeCount, icon: ThumbsUp },
+    { key: "saves", label: countLabels.saves, value: link.saveCount, icon: Bookmark },
+  ];
 
   const handleSourceClick = () => {
     void createLinkViewLog(link.id).catch(() => {
@@ -138,6 +155,24 @@ export default function LinkCard({
             </div>
           ) : null}
 
+          <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-muted-foreground md:text-sm">
+            {countItems.map((item) => {
+              const Icon = item.icon;
+              const formattedCount = formatCount(item.value, locale);
+
+              return (
+                <span
+                  key={item.key}
+                  className="inline-flex items-center gap-1"
+                  aria-label={`${item.label}: ${formattedCount}`}
+                  title={`${item.label}: ${formattedCount}`}
+                >
+                  <Icon className="h-4 w-4" aria-hidden="true" />
+                  {formattedCount}
+                </span>
+              );
+            })}
+          </div>
         </div>
       </div>
     </article>

--- a/src/components/links/LinkList.tsx
+++ b/src/components/links/LinkList.tsx
@@ -6,7 +6,7 @@ import { useUser } from "../../hooks/useUser";
 import { queryKeys } from "../../lib/queryKeys";
 import { fetchLinkViewerStates } from "../../services/links/client";
 import type { LinkContent } from "../../services/links/types";
-import LinkCard from "./LinkCard";
+import LinkCard, { LinkCountLabels } from "./LinkCard";
 
 interface LinkListProps {
   links: LinkContent[];
@@ -15,6 +15,7 @@ interface LinkListProps {
   summaryFallback: string;
   readLabel: string;
   unreadLabel: string;
+  countLabels: LinkCountLabels;
 }
 
 function getPublicLink(link: LinkContent): LinkContent {
@@ -30,6 +31,7 @@ export default function LinkList({
   summaryFallback,
   readLabel,
   unreadLabel,
+  countLabels,
 }: LinkListProps) {
   const { user } = useUser();
   const linkIds = useMemo(() => links.map((link) => link.id), [links]);
@@ -72,6 +74,7 @@ export default function LinkList({
           }
           readLabel={readLabel}
           unreadLabel={unreadLabel}
+          countLabels={countLabels}
         />
       ))}
     </div>

--- a/src/services/links/server.ts
+++ b/src/services/links/server.ts
@@ -228,7 +228,9 @@ async function fetchLinkStatsMap(linkIds: string[]): Promise<Map<string, LinkSta
   const result = await fetchOpenApi<OpenLinkStatsResponse>(
     "/open-api/links/stats",
     searchParams,
-  );
+  ).catch(() => null);
+
+  if (!result?.data) return new Map();
 
   return createLinkStatsMap(result.data);
 }

--- a/src/services/links/server.ts
+++ b/src/services/links/server.ts
@@ -3,10 +3,12 @@ import type {
   FetchOpenLinksParams,
   LinkContent,
   LinkListResult,
+  LinkStatsItem,
   LinkTag,
   OpenLinkDetailResponse,
   OpenLinkItem,
   OpenLinkListResponse,
+  OpenLinkStatsResponse,
   UserProfileImageListResponse,
   UserSearchResponse,
 } from "./types";
@@ -161,6 +163,7 @@ export function normalizeLinkContent(item: OpenLinkItem): LinkContent {
     updatedAt: normalizeString(item.updatedAt),
     viewCount: normalizeCount(item.viewCount),
     likeCount: normalizeCount(item.likeCount),
+    saveCount: normalizeCount(item.saveCount),
     likeStatus: isLinkLikeStatus(item.likeStatus) ? item.likeStatus : undefined,
     isSaved: normalizeBoolean(item.isSaved),
     isRead: normalizeBoolean(item.isRead),
@@ -182,6 +185,52 @@ async function fetchOpenApi<T>(path: string, params?: URLSearchParams): Promise<
   }
 
   return (await response.json()) as T;
+}
+
+function createLinkStatsMap(stats: LinkStatsItem[]): Map<string, LinkStatsItem> {
+  const statsMap = new Map<string, LinkStatsItem>();
+
+  stats.forEach((stat) => {
+    const linkId = normalizeString(stat.linkId);
+    if (linkId) {
+      statsMap.set(linkId, stat);
+    }
+  });
+
+  return statsMap;
+}
+
+function mergeLinkStats(
+  links: LinkContent[],
+  statsMap: Map<string, LinkStatsItem>,
+): LinkContent[] {
+  return links.map((link) => {
+    const stats = statsMap.get(link.id);
+
+    return {
+      ...link,
+      viewCount: normalizeCount(stats?.viewCount) ?? 0,
+      likeCount: normalizeCount(stats?.likeCount) ?? 0,
+      saveCount: normalizeCount(stats?.saveCount) ?? 0,
+    };
+  });
+}
+
+async function fetchLinkStatsMap(linkIds: string[]): Promise<Map<string, LinkStatsItem>> {
+  const uniqueLinkIds = Array.from(new Set(linkIds.filter(Boolean))).slice(0, 100);
+  if (uniqueLinkIds.length === 0) return new Map();
+
+  const searchParams = new URLSearchParams();
+  uniqueLinkIds.forEach((linkId) => {
+    searchParams.append("linkIds", linkId);
+  });
+
+  const result = await fetchOpenApi<OpenLinkStatsResponse>(
+    "/open-api/links/stats",
+    searchParams,
+  );
+
+  return createLinkStatsMap(result.data);
 }
 
 export async function fetchOpenLinks(
@@ -212,15 +261,17 @@ export async function fetchOpenLinks(
   if (params.period) searchParams.set("period", params.period);
   if (params.sort) searchParams.set("sort", params.sort);
 
-  const result = await fetchOpenApi<OpenLinkListResponse>("/open-api/links", searchParams);
+  const result = await fetchOpenApi<OpenLinkListResponse>("/open-api/v1/links", searchParams);
   const links = result.data.content.map(normalizeLinkContent).filter((link) => link.id && link.url);
   const nextCursor = result.data.nextCursor ?? undefined;
+  const statsMap = await fetchLinkStatsMap(links.map((link) => link.id));
+  const linksWithStats = mergeLinkStats(links, statsMap);
   const profileMap = await fetchSourceCompanyProfileMap(
-    getUniqueSourceCompanyUserIds(links),
+    getUniqueSourceCompanyUserIds(linksWithStats),
   );
 
   return {
-    links: applySourceCompanyProfiles(links, profileMap),
+    links: applySourceCompanyProfiles(linksWithStats, profileMap),
     nextCursor,
     hasNext: result.data.hasNext ?? Boolean(nextCursor),
     size: result.data.size ?? params.size ?? 20,
@@ -240,6 +291,8 @@ export async function fetchOpenLinkDetail(linkId: string): Promise<LinkContent> 
   const profileMap = await fetchSourceCompanyProfileMap(
     getUniqueSourceCompanyUserIds([link]),
   );
+  const statsMap = await fetchLinkStatsMap([link.id]);
+  const linkWithStats = mergeLinkStats([link], statsMap)[0] ?? link;
 
-  return applySourceCompanyProfiles([link], profileMap)[0] ?? link;
+  return applySourceCompanyProfiles([linkWithStats], profileMap)[0] ?? linkWithStats;
 }

--- a/src/services/links/types.ts
+++ b/src/services/links/types.ts
@@ -1,8 +1,8 @@
 export type LinkLikeStatus = "LIKE" | "DISLIKE" | "NONE";
-export type LinkListSort = "LATEST" | "VIEW" | "LIKE" | "COMMENT";
+export type LinkListSort = "PUBLISHED" | "LIKE" | "SAVE";
 export type LinkListPeriod = "WEEK" | "MONTH" | "YEAR" | "ALL";
 export type LinkDateRange = "7d" | "30d" | "365d" | "all";
-export type LinkSortOption = "views" | "likes" | "latest" | "comments";
+export type LinkSortOption = "latest" | "likes" | "saves";
 
 export function isLinkLikeStatus(value: unknown): value is LinkLikeStatus {
   return value === "LIKE" || value === "DISLIKE" || value === "NONE";
@@ -27,6 +27,7 @@ export interface LinkContent {
   updatedAt?: string;
   viewCount?: number;
   likeCount?: number;
+  saveCount?: number;
   likeStatus?: LinkLikeStatus;
   isSaved?: boolean;
   isRead?: boolean;
@@ -46,6 +47,12 @@ export interface OpenLinkListResponse {
 export interface OpenLinkDetailResponse {
   status: number;
   data: OpenLinkItem;
+  message?: string;
+}
+
+export interface OpenLinkStatsResponse {
+  status: number;
+  data: LinkStatsItem[];
   message?: string;
 }
 
@@ -112,9 +119,17 @@ export interface OpenLinkItem {
   updatedAt?: string | null;
   viewCount?: number | null;
   likeCount?: number | null;
+  saveCount?: number | null;
   likeStatus?: LinkLikeStatus | null;
   isSaved?: boolean | null;
   isRead?: boolean | null;
+}
+
+export interface LinkStatsItem {
+  linkId?: string | null;
+  viewCount?: number | null;
+  likeCount?: number | null;
+  saveCount?: number | null;
 }
 
 export interface UserProfileImageItem {

--- a/src/views/LinkListPage.tsx
+++ b/src/views/LinkListPage.tsx
@@ -14,7 +14,7 @@ import type {
 type SearchParamValue = string | string[] | undefined;
 
 const DATE_RANGE_OPTIONS: LinkDateRange[] = ["7d", "30d", "365d", "all"];
-const SORT_OPTIONS: LinkSortOption[] = ["views", "likes", "latest", "comments"];
+const SORT_OPTIONS: LinkSortOption[] = ["latest", "likes", "saves"];
 
 const DATE_RANGE_TO_PERIOD: Record<LinkDateRange, LinkListPeriod> = {
   "7d": "WEEK",
@@ -24,10 +24,9 @@ const DATE_RANGE_TO_PERIOD: Record<LinkDateRange, LinkListPeriod> = {
 };
 
 const SORT_OPTION_TO_SORT: Record<LinkSortOption, LinkListSort> = {
-  views: "VIEW",
+  latest: "PUBLISHED",
   likes: "LIKE",
-  latest: "LATEST",
-  comments: "COMMENT",
+  saves: "SAVE",
 };
 
 interface LinkListPageProps {
@@ -63,9 +62,9 @@ function normalizeDateRange(value: SearchParamValue): LinkDateRange {
 
 function normalizeSortOption(value: SearchParamValue): LinkSortOption {
   const rawValue = readFirstParam(value)?.toLowerCase();
-  if (rawValue === "view") return "views";
+  if (rawValue === "published") return "latest";
   if (rawValue === "like") return "likes";
-  if (rawValue === "comment") return "comments";
+  if (rawValue === "save") return "saves";
   if (rawValue && SORT_OPTIONS.includes(rawValue as LinkSortOption)) {
     return rawValue as LinkSortOption;
   }
@@ -172,6 +171,11 @@ export default async function LinkListPage({
       sortBy: value,
     }),
   }));
+  const countLabels = {
+    views: cardT("views"),
+    likes: cardT("likes"),
+    saves: cardT("saves"),
+  };
 
   return (
     <div className="min-h-screen bg-background overflow-x-hidden">
@@ -209,6 +213,7 @@ export default async function LinkListPage({
           summaryFallback={detailT("summaryFallback")}
           readLabel={cardT("read")}
           unreadLabel={cardT("unread")}
+          countLabels={countLabels}
         />
 
         {result.hasNext && result.nextCursor ? (


### PR DESCRIPTION
## 어떤 작업인가요?
- 링크 목록을 `/open-api/v1/links`와 링크 통계 배치 API에 맞춰 연동해 목록에서 조회수, 좋아요수, 저장수를 확인할 수 있게 합니다.

## 어떻게 해결했나요?
**링크 목록 API 변경**
- v1 목록 API의 `PUBLISHED`, `LIKE`, `SAVE` 정렬 기준에 맞춰 프론트 정렬 매핑을 조정했습니다.
- 기존 작성자/태그/기간/커서 필터 흐름은 유지했습니다.

**통계 배치 병합**
- `/open-api/links/stats`를 링크 ID 목록으로 조회하고 목록/상세 링크 데이터에 누적 통계를 병합했습니다.
- 통계 이력이 없어 응답에서 제외된 링크는 0으로 표시하도록 처리했습니다.

**목록 UI 표시 확장**
- 링크 카드에 조회수, 좋아요수, 저장수 표시를 추가했습니다.
- 저장순 정렬 라벨과 통계 라벨을 다국어 메시지에 추가했습니다.

## 중요한 변경 사항은 무엇인가요?
### 링크 목록 v1 API 전환

**정렬 파라미터 변경**
- **변경 이유**: 새 링크 목록 API가 `PUBLISHED`, `LIKE`, `SAVE`만 지원하기 때문입니다.
- **수정 파일**: `src/views/LinkListPage.tsx`, `src/services/links/types.ts`

**통계 응답 병합**
- **변경 이유**: v1 목록 응답은 정적 콘텐츠 중심이고 누적 통계는 별도 batch API에서 제공되기 때문입니다.
- **수정 파일**: `src/services/links/server.ts`

### 링크 카드 통계 표시

**목록 통계 노출**
- **변경 이유**: 사용자가 링크 목록에서 조회수, 좋아요수, 저장수를 바로 비교할 수 있어야 하기 때문입니다.
- **수정 파일**: `src/components/links/LinkCard.tsx`, `src/components/links/LinkList.tsx`

**다국어 라벨 추가**
- **변경 이유**: 새 정렬/통계 UI 텍스트가 모든 지원 locale에서 표시되어야 하기 때문입니다.
- **수정 파일**: `messages/ko.json`, `messages/en.json`, `messages/ja.json`, `messages/zh.json`

Co-Authored-By: Codex <codex@openai.com>
